### PR TITLE
feat(schema): prepare schema for WordPress to Sanity bulk migration

### DIFF
--- a/sanity/schemaTypes/documents/post.ts
+++ b/sanity/schemaTypes/documents/post.ts
@@ -67,7 +67,8 @@ export const post = defineType({
           },
         },
       ],
-      validation: (rule) => rule.required(),
+      // No required validation: bulk-imported posts may not have a source
+      // image; editors can attach a cover image manually after import.
     }),
     defineField({
       name: 'date',

--- a/sanity/schemaTypes/index.ts
+++ b/sanity/schemaTypes/index.ts
@@ -2,6 +2,8 @@ import { person } from './documents/person'
 import { page } from './documents/page'
 import { post } from './documents/post'
 import { callToAction } from './objects/callToAction'
+import { divider } from './objects/divider'
+import { embed } from './objects/embed'
 import { infoSection } from './objects/infoSection'
 import { settings } from './singletons/settings'
 import { link } from './objects/link'
@@ -20,4 +22,6 @@ export const schemaTypes = [
   infoSection,
   callToAction,
   link,
+  divider,
+  embed,
 ]

--- a/sanity/schemaTypes/objects/blockContent.tsx
+++ b/sanity/schemaTypes/objects/blockContent.tsx
@@ -110,6 +110,20 @@ export const blockContent = defineType({
           title: 'Caption',
           description: 'Optional caption for the image.',
         }),
+        defineField({
+          name: 'alignment',
+          title: 'Alignment',
+          type: 'string',
+          description: 'How the image is laid out within the surrounding flow.',
+          options: {
+            list: [
+              {title: 'Left', value: 'left'},
+              {title: 'Center', value: 'center'},
+              {title: 'Right', value: 'right'},
+            ],
+            layout: 'radio',
+          },
+        }),
       ],
     }),
     defineArrayMember({
@@ -125,7 +139,7 @@ export const blockContent = defineType({
             list: [
               {title: 'YouTube', value: 'youtube'},
               {title: 'Vimeo', value: 'vimeo'},
-              {title: 'Direct URL', value: 'url'},
+              {title: 'Self-hosted file', value: 'url'},
             ],
             layout: 'radio',
           },
@@ -135,8 +149,24 @@ export const blockContent = defineType({
           name: 'url',
           title: 'Video URL',
           type: 'url',
-          description: 'Full URL to the video (YouTube, Vimeo, or direct video URL)',
-          validation: (Rule) => Rule.required(),
+          description:
+            'Full external URL (YouTube or Vimeo). Leave empty for self-hosted files.',
+          hidden: ({parent}) => parent?.videoType === 'url',
+          validation: (Rule) =>
+            Rule.custom((value, context: any) => {
+              if (context.parent?.videoType !== 'url' && !value) {
+                return 'URL is required for YouTube and Vimeo videos'
+              }
+              return true
+            }),
+        }),
+        defineField({
+          name: 'videoFile',
+          title: 'Video file',
+          type: 'file',
+          options: {accept: 'video/*'},
+          description: 'Self-hosted video file. Used when video type is "Self-hosted file".',
+          hidden: ({parent}) => parent?.videoType !== 'url',
         }),
         defineField({
           name: 'title',
@@ -242,5 +272,9 @@ export const blockContent = defineType({
         },
       },
     }),
+    // Divider and embed are registered as standalone object types
+    // (see ./divider.ts and ./embed.ts) and referenced by name here.
+    defineArrayMember({type: 'divider'}),
+    defineArrayMember({type: 'embed'}),
   ],
 })

--- a/sanity/schemaTypes/objects/divider.ts
+++ b/sanity/schemaTypes/objects/divider.ts
@@ -1,0 +1,30 @@
+import {defineField, defineType} from 'sanity'
+
+/**
+ * Horizontal-rule-style separator.
+ *
+ * Sanity requires every object to declare at least one field, so the block
+ * carries a single read-only `style` marker. Editors don't see it; the
+ * value is fixed and the renderer always produces the same separator.
+ */
+export const divider = defineType({
+  name: 'divider',
+  title: 'Divider',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'style',
+      title: 'Style',
+      type: 'string',
+      options: {
+        list: [{title: 'Default separator', value: 'default'}],
+      },
+      initialValue: 'default',
+      readOnly: true,
+      hidden: true,
+    }),
+  ],
+  preview: {
+    prepare: () => ({title: '———'}),
+  },
+})

--- a/sanity/schemaTypes/objects/embed.ts
+++ b/sanity/schemaTypes/objects/embed.ts
@@ -1,0 +1,36 @@
+import {defineField, defineType} from 'sanity'
+
+/**
+ * Generic third-party embed.
+ *
+ * Use this for iframes that are not covered by the more specific `video`
+ * type — Spotify, Twitter, CodePen, custom embeds, etc. The renderer decides
+ * how to handle the URL (e.g. by sniffing the host or using oEmbed).
+ */
+export const embed = defineType({
+  name: 'embed',
+  title: 'Embed',
+  type: 'object',
+  fields: [
+    defineField({
+      name: 'url',
+      title: 'URL',
+      type: 'url',
+      description: 'Full URL of the resource to embed.',
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: 'caption',
+      title: 'Caption',
+      type: 'string',
+      description: 'Optional caption rendered alongside the embed.',
+    }),
+  ],
+  preview: {
+    select: {title: 'caption', subtitle: 'url'},
+    prepare: ({title, subtitle}) => ({
+      title: title || 'Embed',
+      subtitle: subtitle || 'No URL',
+    }),
+  },
+})

--- a/sanity/schemaTypes/objects/link.ts
+++ b/sanity/schemaTypes/objects/link.ts
@@ -16,7 +16,10 @@ export const link = defineType({
       name: 'linkType',
       title: 'Link Type',
       type: 'string',
-      initialValue: 'url',
+      // The default has to match one of the option values below; the
+      // previous `'url'` did not, so newly-created links opened with no
+      // linkType selected at all.
+      initialValue: 'href',
       options: {
         list: [
           { title: 'URL', value: 'href' },


### PR DESCRIPTION
## Summary

Prepare the studio schema as a clean import target for the bulk WordPress to Sanity migration. Six additive changes (one image field, one video field, two new block types, plus the matching registrations), one loosened validation rule, and one pre-existing bug fix that was caught while in here.

## Why

Walking the corpus of 165 records that the migrator produces against the existing schema surfaced a handful of cases where the import would either lose data or trigger validation noise:

| Migrator emits | Studio schema | Outcome before this PR |
|---|---|---|
| `image.alignment: 'center'` (~8 records) | no such field | silently stored as unknown field, invisible to editors |
| `video.videoFile.asset` (2 self-hosted videos) | no such field | uploaded asset orphaned in Sanity Assets, no playback in studio |
| `video.url = undefined` (same 2 self-hosted videos) | `rule.required()` | red squiggle on every self-hosted video |
| `coverImage.asset = undefined` (14 cover-less records) | `rule.required()` | red squiggle on 14 posts |

After this PR all four are clean.

## Commits

### 1. `fix(schema): correct link.linkType initialValue`

`objects/link.ts` had `initialValue: 'url'` but the options list only contains `'href'`, `'page'`, `'post'`. Newly created links would open with no type selected. Now defaults to `'href'`.

Pre-existing bug, caught while reviewing the schema. One-line fix.

### 2. `feat(schema): add fields and types for WordPress migration`

Block content (`objects/blockContent.tsx`):
- **Add `image.alignment`** — `'left' | 'center' | 'right'` radio.
- **Add `video.videoFile`** — `file` field, hidden unless `videoType === 'url'`. The migrator uploads the file and points `videoFile.asset` at it.
- **Loosen `video.url`** — was always required; now required only for YouTube/Vimeo. Self-hosted files use `videoFile`, not `url`.
- **Rename `'Direct URL'` → `'Self-hosted file'`** in the `videoType` option list. Editors immediately understand the option.
- **Register `divider` and `embed`** as block-content members.

New object types:
- **`objects/divider.ts`** — horizontal-rule-style separator. Sanity requires every object to declare at least one field, so the block carries one hidden read-only `style: 'default'` marker.
- **`objects/embed.ts`** — generic third-party embed (URL + optional caption) for iframes that are not YouTube or Vimeo.

Documents (`documents/post.ts`):
- **Drop `coverImage` `rule.required()`** — bulk-imported posts may not have a source image; editors can attach one manually post-import.

## Verification

- `npx tsc --noEmit` → **0 errors**
- `yarn sanity schema validate` → **0 errors, 0 warnings**
- `yarn lint` → **clean**
- `yarn vitest run` → **9/9 pass**

## What's deliberately not changed

- Studio-specific document types and singletons (`person`, `callToAction`, `infoSection`, `settings`, `page.pageBuilder`) are untouched — none of them are populated by the migrator and they don't need to be.
- The inline `link` annotation inside `blockContent` is left as-is. Replacing it with a reference to the standalone `link` type triggered both a TypeScript mismatch (`ValidationBuilder` vs `SchemaValidationValue`) and a Sanity runtime "Could not resolve jsonType" error, in every shorthand I tried. The standalone `link` type is still used by `callToAction.link`, and the `initialValue` fix in commit 1 benefits both call sites once an editor uses the standalone type.
- Studio code style (single quotes, tight braces) is preserved throughout.
