### PR TITLE
fix(organs): 2-col grid + dedupe city counts

### DIFF
--- a/app/(site)/organs/page.tsx
+++ b/app/(site)/organs/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next'
 import { Hero } from '@/app/components/landing/Hero'
 import { OrgansArchive } from '@/app/components/landing/OrgansArchive'
 import type { LandingOrgan } from '@/app/components/landing/OrganCard'
-import { normaliseCityParam } from '@/app/components/landing/archiveUtil'
+import { countCitiesFromRows, normaliseCityParam } from '@/app/components/landing/archiveUtil'
 import {
   archiveOrgansCountQuery,
   archiveOrgansQuery,
@@ -51,10 +51,7 @@ export default async function Page({ searchParams }: { searchParams: Promise<Sea
     ? new Date(stats.firstDate).getUTCFullYear()
     : new Date().getUTCFullYear()
 
-  const cityCounts: Record<string, number> = {}
-  for (const c of cities ?? []) {
-    if (c.city) cityCounts[c.city] = (cityCounts[c.city] ?? 0) + 1
-  }
+  const cityCounts = countCitiesFromRows(cities)
 
   const filtered = filteredCount ?? 0
 

--- a/app/components/landing/OrgansArchive.tsx
+++ b/app/components/landing/OrgansArchive.tsx
@@ -13,7 +13,7 @@ type OrgansArchiveProps = {
   initialOrgans: LandingOrgan[]
   totalCount: number
   cityCounts: Record<string, number>
-  /** Active city filter \u2014 empty string when "all". */
+  /** Active city filter — empty string when "all". */
   city: string
 }
 
@@ -88,7 +88,7 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
             shown={organs.length}
             total={totalCount}
           />
-          <div className="grid gap-x-8 gap-y-10 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-x-8 gap-y-10 grid-cols-1 sm:grid-cols-2">
             {grouped.map(({ organ, year, isYearStart }, i) => (
               <YearAwareCell
                 key={organ._id}
@@ -104,13 +104,13 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
           {!exhausted && (
             <div ref={sentinelRef} className="mt-12 flex justify-center" aria-hidden="true">
               <span className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint">
-                {loading ? 'Loading\u2026' : ''}
+                {loading ? 'Loading…' : ''}
               </span>
             </div>
           )}
           {exhausted && organs.length > PAGE_SIZE && (
             <p className="mt-14 text-center font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint">
-              \u2014 end of the archive \u2014
+              — end of the archive —
             </p>
           )}
         </div>
@@ -146,7 +146,7 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
                 href={cityHref('')}
                 className="text-ink-soft border-b border-rule pb-[3px] transition-colors duration-200 hover:text-accent hover:border-accent"
               >
-                Browse all &nbsp;\u2192
+                Browse all &nbsp;→
               </Link>
             </div>
           </aside>
@@ -190,7 +190,7 @@ function ArchiveHeader({
             href={cityHref('')}
             className="text-ink-soft border-b border-rule pb-[2px] transition-colors duration-200 hover:text-accent hover:border-accent"
           >
-            clear filter \u2715
+            clear filter ✕
           </Link>
         )}
       </span>

--- a/app/components/landing/Placeholder.spec.tsx
+++ b/app/components/landing/Placeholder.spec.tsx
@@ -38,7 +38,7 @@ describe('Placeholder', () => {
       const el = container.querySelector('.placeholder-stripe') as HTMLElement
       seen.add(el.style.getPropertyValue('--stripe-a'))
     }
-    // Four tones \u2192 four distinct --stripe-a values.
+    // Four tones → four distinct --stripe-a values.
     expect(seen.size).toBe(4)
   })
 

--- a/app/components/landing/archiveActions.ts
+++ b/app/components/landing/archiveActions.ts
@@ -9,7 +9,7 @@ import type { LandingOrgan } from './OrganCard'
  * intersection observer crosses the load-more sentinel. Returns the next
  * `limit` organs starting at `offset`, optionally filtered by `city`.
  *
- * `city` is an empty string for "no filter" \u2014 matches the GROQ sentinel.
+ * `city` is an empty string for "no filter" — matches the GROQ sentinel.
  */
 export async function loadMoreOrgans({
   offset,

--- a/app/components/landing/archiveUtil.spec.ts
+++ b/app/components/landing/archiveUtil.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   cityHref,
+  countCitiesFromRows,
   normaliseCityParam,
   sortedCitiesForSidebar,
   withYearGroups,
@@ -131,6 +132,47 @@ describe('normaliseCityParam', () => {
 
   it('returns the empty string for non-string non-array input via type coercion', () => {
     expect(normaliseCityParam(123 as unknown as string)).toBe('')
+  })
+})
+
+describe('countCitiesFromRows', () => {
+  it('counts plain city values correctly', () => {
+    const out = countCitiesFromRows([
+      { city: 'Urk' },
+      { city: 'Urk' },
+      { city: 'Zwolle' },
+      { city: 'Urk' },
+    ])
+    expect(out).toEqual({ Urk: 3, Zwolle: 1 })
+  })
+
+  it('collapses stega-encoded copies of the same city into one entry', () => {
+    // Sanity Live appends a stega payload of zero-width chars to every fetched
+    // string so the Visual Editor can map a DOM node back to its source field.
+    // Two strings that read as "Urk" but carry different payloads must count
+    // as the same city.
+    const stegaA = 'Urk\u200B\u200C\u200B\u200C'
+    const stegaB = 'Urk\u200B\u200B\u200C\u200B\u200C\u200B\u200C\u200B'
+    const out = countCitiesFromRows([{ city: stegaA }, { city: stegaB }, { city: 'Urk' }])
+    expect(Object.keys(out)).toEqual(['Urk'])
+    expect(out.Urk).toBe(3)
+  })
+
+  it('skips rows with no city or with a city that cleans to empty', () => {
+    const out = countCitiesFromRows([
+      { city: 'Zwolle' },
+      { city: null },
+      { city: '' },
+      {},
+      // A pure stega-payload string that cleans to empty:
+      { city: '\u200B\u200C\u200B\u200C' },
+    ])
+    expect(out).toEqual({ Zwolle: 1 })
+  })
+
+  it('handles null/undefined input gracefully', () => {
+    expect(countCitiesFromRows(null)).toEqual({})
+    expect(countCitiesFromRows(undefined)).toEqual({})
   })
 })
 

--- a/app/components/landing/archiveUtil.ts
+++ b/app/components/landing/archiveUtil.ts
@@ -1,3 +1,5 @@
+import { stegaClean } from '@sanity/client/stega'
+
 import type { LandingOrgan } from './OrganCard'
 
 /**
@@ -76,4 +78,27 @@ export function sortedCitiesForSidebar(
   return Object.entries(cityCounts)
     .map(([city, count]) => ({ city, count }))
     .sort((a, b) => b.count - a.count || a.city.localeCompare(b.city))
+}
+
+/**
+ * Count cities from `landingCitiesQuery` rows, stega-cleaning each value.
+ *
+ * Sanity Live encodes invisible stega markers into every fetched string so
+ * the Visual Editor can map a rendered DOM node back to a source field.
+ * That makes two "Urk" strings sourced from different organ docs into
+ * different JavaScript values, which would otherwise collapse them into
+ * separate sidebar entries with `count: 1` each. Cleaning before keying
+ * gives us one entry per real city with the right total.
+ */
+export function countCitiesFromRows(
+  rows: Array<{ city?: string | null }> | null | undefined,
+): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const row of rows ?? []) {
+    if (!row.city) continue
+    const cleaned = stegaClean(row.city)
+    if (!cleaned) continue
+    out[cleaned] = (out[cleaned] ?? 0) + 1
+  }
+  return out
 }

--- a/app/components/landing/renderEmphasised.spec.tsx
+++ b/app/components/landing/renderEmphasised.spec.tsx
@@ -59,7 +59,7 @@ describe('renderInlineItalic', () => {
   })
 
   it('does not wrap a stray single asterisk', () => {
-    // No pair \u2192 the regex split keeps the string as one plain segment.
+    // No pair → the regex split keeps the string as one plain segment.
     const out = html(renderInlineItalic('A * stray asterisk'))
     expect(out).not.toContain('<em')
     expect(out).toContain('A * stray asterisk')


### PR DESCRIPTION
## What this fixes

Two issues from #13:

1. **Grid was 3-col when 2-col was the intent.** Reverts the archive grid to `grid-cols-1 sm:grid-cols-2`. 3-col was too dense for the editorial card style; matches the homepage `Recent visits` rhythm.
2. **City sidebar duplicated entries** — `Urk · 1` shown 7 times instead of `Urk · 7` once. Sanity Live attaches a unique stega payload (zero-width chars) to every fetched string so the Visual Editor can map a rendered DOM node back to its source organ doc. That makes 7 visits to the same city into 7 distinct JavaScript strings, which collapsed in the sidebar as 7 separate entries with `count: 1` each.

## Fix

New `countCitiesFromRows(rows)` helper in `archiveUtil.ts` that calls `stegaClean` on each city before keying the count map. The page route uses it in place of the inline loop.

## Verified

- `yarn check-types` ✅
- `yarn lint` ✅
- `yarn coverage` ✅ (156 tests, 100% across the board still holding)
- Smoke test: 93 unique sidebar links, no duplicates; grid renders 2 columns at sm and up.