### PR TITLE
feat(i18n): bulk UI string extraction, slug translation, stale badge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ TRANSLATOR_PROVIDER="gemini" # gemini | anthropic | openai (default: gemini)
 GOOGLE_AI_API_KEY="" # Required when TRANSLATOR_PROVIDER=gemini
 ANTHROPIC_API_KEY="" # Required when TRANSLATOR_PROVIDER=anthropic
 OPENAI_API_KEY="" # Required when TRANSLATOR_PROVIDER=openai
+# Per-provider model overrides. Defaults are tuned for cost:
+#   GEMINI_MODEL: gemini-2.5-flash (default)
+#   ANTHROPIC_MODEL: claude-sonnet-4-5
+#   OPENAI_MODEL: gpt-4o
+GEMINI_MODEL="gemini-2.5-flash"
 
 # Phase-1 rollout flag. When "false", the public site is locked to /en/
 # (every other /{locale}/... redirects to /en/...) and the language picker

--- a/app/components/landing/About.tsx
+++ b/app/components/landing/About.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { Image } from 'next-sanity/image'
 import { PortableText, type PortableTextBlock } from 'next-sanity'
@@ -77,13 +78,14 @@ const letterComponents = {
 }
 
 function Crumbs() {
+  const tCrumbs = useTranslations('Crumbs')
   return (
     <div className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint flex items-center gap-3 mb-14">
       <Link href="/" className="transition-colors hover:text-accent">
-        Home
+        {tCrumbs('home')}
       </Link>
       <span className="opacity-40">/</span>
-      <span className="text-ink">About me</span>
+      <span className="text-ink">{tCrumbs('about')}</span>
     </div>
   )
 }
@@ -393,12 +395,15 @@ function Timeline({
   entries: TimelineEntry[] | null
   attr: StegaAttr
 }) {
+  const t = useTranslations('About')
   if (!entries || entries.length === 0) return null
   const summaryLines = (summary ?? '').split('\n').filter(Boolean)
   return (
     <section className="max-w-[1240px] mx-auto px-6 md:px-12 pt-24" data-screen-label="timeline">
-      <SecHead num="01" label="Trajectory">
-        Een korte <em className="italic font-normal">chronologie</em> — hoe ik hier kwam.
+      <SecHead num={t('trajectoryNum')} label={t('trajectoryLabel')}>
+        {t.rich('trajectoryHeading', {
+          em: (chunks) => <em className="italic font-normal">{chunks}</em>,
+        })}
       </SecHead>
       <div className="grid grid-cols-1 lg:grid-cols-[220px_minmax(0,1fr)] gap-8 lg:gap-16 items-start">
         {summaryLines.length > 0 && (
@@ -448,11 +453,14 @@ function Repertoire({
   cards: RepertoireCard[] | null
   attr: StegaAttr
 }) {
+  const t = useTranslations('About')
   if (!cards || cards.length === 0) return null
   return (
     <section className="max-w-[1240px] mx-auto px-6 md:px-12 pt-24" data-screen-label="repertoire">
-      <SecHead num="02" label="What I play">
-        Repertoire waar ik naar <em className="italic font-normal">terugkeer</em>.
+      <SecHead num={t('repertoireNum')} label={t('repertoireLabel')}>
+        {t.rich('repertoireHeading', {
+          em: (chunks) => <em className="italic font-normal">{chunks}</em>,
+        })}
       </SecHead>
       <div className="grid grid-cols-1 lg:grid-cols-[220px_minmax(0,1fr)] gap-8 lg:gap-16">
         {intro && (
@@ -579,6 +587,7 @@ function Contact({
 }
 
 function EmptyState() {
+  const t = useTranslations('About')
   return (
     <section className="max-w-[840px] mx-auto px-6 md:px-12 py-32 text-center">
       <Crumbs />
@@ -586,14 +595,17 @@ function EmptyState() {
         className="font-serif font-light leading-none m-0 mb-8 text-balance"
         style={{ fontSize: 'clamp(40px, 5vw, 64px)', letterSpacing: '-0.012em' }}
       >
-        About me
+        {t('emptyTitle')}
       </h1>
       <p className="font-serif italic text-2xl text-ink-soft m-0 mb-4 max-w-[40ch] mx-auto">
-        Deze pagina is nog niet ingericht in de Studio.
+        {t('emptyBody')}
       </p>
       <p className="font-serif italic text-lg text-ink-faint m-0 max-w-[50ch] mx-auto">
-        Open <span className="not-italic font-mono text-sm text-ink">/admin → About page</span>{' '}
-        om de inhoud toe te voegen.
+        {t.rich('emptyHint', {
+          code: (chunks) => (
+            <span className="not-italic font-mono text-sm text-ink">{chunks}</span>
+          ),
+        })}
       </p>
     </section>
   )

--- a/app/components/landing/Elsewhere.tsx
+++ b/app/components/landing/Elsewhere.tsx
@@ -1,3 +1,4 @@
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { PortableText, type PortableTextBlock } from 'next-sanity'
 
@@ -41,18 +42,20 @@ const introComponents = {
 }
 
 function Crumbs() {
+  const tCrumbs = useTranslations('Crumbs')
   return (
     <div className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint flex items-center gap-3 mb-14">
       <Link href="/" className="transition-colors hover:text-accent">
-        Home
+        {tCrumbs('home')}
       </Link>
       <span className="opacity-40">/</span>
-      <span className="text-ink">Elsewhere</span>
+      <span className="text-ink">{tCrumbs('elsewhere')}</span>
     </div>
   )
 }
 
 function EmptyState() {
+  const t = useTranslations('Elsewhere')
   return (
     <section className="max-w-[840px] mx-auto px-6 md:px-12 py-32 text-center">
       <Crumbs />
@@ -60,14 +63,17 @@ function EmptyState() {
         className="font-serif font-light leading-none m-0 mb-8 text-balance"
         style={{ fontSize: 'clamp(40px, 5vw, 64px)', letterSpacing: '-0.012em' }}
       >
-        Elsewhere
+        {t('emptyTitle')}
       </h1>
       <p className="font-serif italic text-2xl text-ink-soft m-0 mb-4 max-w-[40ch] mx-auto">
-        Deze pagina is nog niet ingericht in de Studio.
+        {t('emptyBody')}
       </p>
       <p className="font-serif italic text-lg text-ink-faint m-0 max-w-[50ch] mx-auto">
-        Open <span className="not-italic font-mono text-sm text-ink">/admin → Elsewhere page</span>{' '}
-        om links toe te voegen.
+        {t.rich('emptyHint', {
+          code: (chunks) => (
+            <span className="not-italic font-mono text-sm text-ink">{chunks}</span>
+          ),
+        })}
       </p>
     </section>
   )
@@ -83,6 +89,7 @@ export function Elsewhere({
   if (!data) return <EmptyState />
   const elsewhereId = data._id ?? `elsewhere-${locale}`
   const elsewhereAttr = stegaAttrFor(elsewhereId, 'elsewhere')
+  const t = useTranslations('Elsewhere')
 
   return (
     <main className="max-w-[1240px] mx-auto px-6 md:px-12 pt-8 pb-32" data-screen-label="elsewhere">
@@ -104,7 +111,7 @@ export function Elsewhere({
           letterSpacing: '-0.012em',
         }}
       >
-        {data.title || 'Elsewhere'}
+        {data.title || t('title')}
       </h1>
 
       {data.intro && data.intro.length > 0 && (
@@ -184,7 +191,7 @@ export function Elsewhere({
       )}
 
       {(!data.groups || data.groups.length === 0) && (
-        <p className="font-serif italic text-ink-faint text-lg">Nog geen links toegevoegd.</p>
+        <p className="font-serif italic text-ink-faint text-lg">{t('noLinks')}</p>
       )}
     </main>
   )

--- a/app/components/landing/Hero.tsx
+++ b/app/components/landing/Hero.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from 'next-intl'
+
 import { Horizon } from './Horizon'
 import { Crumbs, type CrumbItem } from './Crumbs'
 import { renderEmphasised } from './renderEmphasised'
@@ -66,17 +68,16 @@ export function Hero({
   crumbs,
   copy,
 }: HeroProps) {
+  const t = useTranslations('Hero')
   const ORGANS_PAGE_ID = `organsPage-${locale}`
   const organsAttr = (path: string) =>
     dataAttr({ id: ORGANS_PAGE_ID, type: ORGANS_PAGE_TYPE, path }).toString()
-  const kickerLeft = copy?.kickerLeft ?? 'Field notes'
-  const kickerRight = copy?.kickerRight ?? 'From the organ loft'
-  const heading = copy?.heading ?? 'Visits to {{old organs}}'
-  const tagline =
-    copy?.tagline ??
-    'Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.'
-  const cornerLeftSub = copy?.cornerLeftSub ?? 'A field journal'
-  const cornerRightSub = copy?.cornerRightSub ?? 'The low countries'
+  const kickerLeft = copy?.kickerLeft ?? t('kickerLeftFallback')
+  const kickerRight = copy?.kickerRight ?? t('kickerRightFallback')
+  const heading = copy?.heading ?? t('headingFallback')
+  const tagline = copy?.tagline ?? t('taglineFallback')
+  const cornerLeftSub = copy?.cornerLeftSub ?? t('cornerLeftSubFallback')
+  const cornerRightSub = copy?.cornerRightSub ?? t('cornerRightSubFallback')
 
   return (
     <section
@@ -122,7 +123,7 @@ export function Hero({
 
       {/* corner editorial meta — top left */}
       <div className="hidden md:block absolute top-[68px] left-12 z-[3] font-mono text-[10px] tracking-[0.18em] uppercase text-ink-faint">
-        Since {firstYear} · {totalCount} organs
+        {t('stats', { firstYear, totalCount })}
         <span
           data-sanity={organsAttr('cornerLeftSub')}
           className="block mt-0.5 font-serif italic text-sm normal-case tracking-[0.04em] text-ink"

--- a/app/components/landing/JournalArticle.tsx
+++ b/app/components/landing/JournalArticle.tsx
@@ -1,3 +1,4 @@
+import { useFormatter, useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { Image } from 'next-sanity/image'
 import type { PortableTextBlock } from 'next-sanity'
@@ -47,23 +48,17 @@ export type JournalDetail = {
   content: PortableTextBlock[] | null
 }
 
-const CATEGORY_LABEL: Record<string, string> = {
-  travelogue: 'Travelogue',
-  workshop: 'Workshop',
-  memorial: 'In memoriam',
-  'home-organ': 'Home organ',
-  biography: 'Biography',
-  news: 'News',
-  collection: 'Collection',
-  other: 'Field note',
-}
-
-const fmtLong = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-GB', {
-    day: '2-digit',
-    month: 'long',
-    year: 'numeric',
-  })
+const CATEGORY_KEYS = [
+  'travelogue',
+  'workshop',
+  'memorial',
+  'home-organ',
+  'biography',
+  'news',
+  'collection',
+  'other',
+] as const
+type CategoryKey = (typeof CATEGORY_KEYS)[number]
 
 function readMinutes(content: PortableTextBlock[] | null): number {
   if (!content) return 0
@@ -79,16 +74,22 @@ function readMinutes(content: PortableTextBlock[] | null): number {
   return Math.max(1, Math.ceil(words / 200))
 }
 
-function categoryLabel(category: JournalCategory | null): string {
-  if (!category) return CATEGORY_LABEL.other
-  return CATEGORY_LABEL[category] ?? CATEGORY_LABEL.other
+function useCategoryLabel(): (category: JournalCategory | null) => string {
+  const t = useTranslations('JournalArticle.categories')
+  return (category) => {
+    const key = (category && (CATEGORY_KEYS as readonly string[]).includes(category)
+      ? category
+      : 'other') as CategoryKey
+    return t(key as never)
+  }
 }
 
 function Crumbs() {
+  const t = useTranslations('JournalArticle')
   return (
     <div className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint flex items-center gap-3 mb-16">
       <Link href="/" className="transition-colors hover:text-accent">
-        The journal
+        {t('breadcrumbHome')}
       </Link>
     </div>
   )
@@ -111,6 +112,9 @@ function Header({
   date: string
   readMin: number
 }) {
+  const t = useTranslations('JournalArticle')
+  const format = useFormatter()
+  const categoryLabel = useCategoryLabel()
   const padWidth = Math.max(2, String(totalCount || position).length)
   const numLabel = `N° ${String(position).padStart(padWidth, '0')}`
   return (
@@ -130,11 +134,13 @@ function Header({
         {title}
       </h1>
       <div className="inline-flex items-center justify-center flex-wrap gap-3.5 font-mono text-[11px] tracking-[0.16em] uppercase text-ink-faint">
-        <span data-sanity={journalAttr(entryId, 'date')}>{fmtLong(date)}</span>
+        <span data-sanity={journalAttr(entryId, 'date')}>
+          {format.dateTime(new Date(date), { day: '2-digit', month: 'long', year: 'numeric' })}
+        </span>
         {readMin > 0 && (
           <>
             <span className="w-[3px] h-[3px] bg-ink-faint rounded-full opacity-60" />
-            <span>{readMin} min read</span>
+            <span>{t('minRead', { count: readMin })}</span>
           </>
         )}
       </div>
@@ -205,21 +211,29 @@ function Cover({
 }
 
 function NeighborLink({ side, entry }: { side: 'prev' | 'next'; entry: JournalNeighbor }) {
+  const t = useTranslations('JournalArticle')
+  const format = useFormatter()
+  const categoryLabel = useCategoryLabel()
   if (!entry) {
     return (
       <div className={side === 'next' ? 'md:text-right' : ''}>
         <p className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-3.5">
-          {side === 'prev' ? '← Previous entry' : 'Next entry →'}
+          {side === 'prev' ? t('previousEntry') : t('nextEntry')}
         </p>
-        <p className="font-serif italic text-ink-faint m-0">— end of the journal —</p>
+        <p className="font-serif italic text-ink-faint m-0">{t('endOfJournal')}</p>
       </div>
     )
   }
-  const meta = [categoryLabel(entry.category), fmtLong(entry.date)].filter(Boolean).join(' · ')
+  const meta = [
+    categoryLabel(entry.category),
+    format.dateTime(new Date(entry.date), { day: '2-digit', month: 'long', year: 'numeric' }),
+  ]
+    .filter(Boolean)
+    .join(' · ')
   return (
     <div className={side === 'next' ? 'md:text-right' : ''}>
       <p className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-3.5">
-        {side === 'prev' ? '← Previous entry' : 'Next entry →'}
+        {side === 'prev' ? t('previousEntry') : t('nextEntry')}
       </p>
       <Link
         href={`/journal/${entry.slug}`}

--- a/app/components/landing/JournalHero.tsx
+++ b/app/components/landing/JournalHero.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from 'next-intl'
+
 import { Horizon } from './Horizon'
 import { Crumbs, type CrumbItem } from './Crumbs'
 import { renderEmphasised } from './renderEmphasised'
@@ -30,18 +32,17 @@ type JournalHeroProps = {
  * variant's church + windmill.
  */
 export function JournalHero({ locale, totalCount, firstYear, crumbs, copy }: JournalHeroProps) {
+  const t = useTranslations('JournalHero')
   const JOURNAL_PAGE_ID = `journalPage-${locale}`
   const journalAttr = (path: string) =>
     dataAttr({ id: JOURNAL_PAGE_ID, type: JOURNAL_PAGE_TYPE, path }).toString()
 
-  const kickerLeft = copy?.kickerLeft ?? 'Writings'
-  const kickerRight = copy?.kickerRight ?? 'A field journal'
-  const heading = copy?.heading ?? 'The {{Journal}}'
-  const tagline =
-    copy?.tagline ??
-    'Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.'
-  const cornerLeftSub = copy?.cornerLeftSub ?? 'Notes between visits'
-  const cornerRightSub = copy?.cornerRightSub ?? 'The low countries'
+  const kickerLeft = copy?.kickerLeft ?? t('kickerLeftFallback')
+  const kickerRight = copy?.kickerRight ?? t('kickerRightFallback')
+  const heading = copy?.heading ?? t('headingFallback')
+  const tagline = copy?.tagline ?? t('taglineFallback')
+  const cornerLeftSub = copy?.cornerLeftSub ?? t('cornerLeftSubFallback')
+  const cornerRightSub = copy?.cornerRightSub ?? t('cornerRightSubFallback')
 
   return (
     <section
@@ -63,7 +64,7 @@ export function JournalHero({ locale, totalCount, firstYear, crumbs, copy }: Jou
 
       {/* corner editorial meta — top left */}
       <div className="hidden md:block absolute top-[68px] left-12 z-[3] font-mono text-[10px] tracking-[0.18em] uppercase text-ink-faint">
-        Since {firstYear} · {totalCount} entries
+        {t('stats', { firstYear, totalCount })}
         <span
           data-sanity={journalAttr('cornerLeftSub')}
           className="block mt-0.5 font-serif italic text-sm normal-case tracking-[0.04em] text-ink"

--- a/app/components/landing/JournalList.tsx
+++ b/app/components/landing/JournalList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { useFormatter, useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { Image } from 'next-sanity/image'
 import { stegaClean } from '@sanity/client/stega'
@@ -38,34 +39,17 @@ type JournalListProps = {
 
 const PAGE_SIZE = 8
 
-const CATEGORY_LABEL: Record<string, string> = {
-  travelogue: 'Travel',
-  workshop: 'Workshop',
-  memorial: 'Memorial',
-  'home-organ': 'Home organ',
-  biography: 'Biography',
-  news: 'News',
-  collection: 'Collection',
-  other: 'Other',
-}
-
-const CATEGORY_KIND: Record<string, string> = {
-  travelogue: 'travelogue',
-  workshop: 'visit',
-  memorial: 'memorial',
-  'home-organ': 'home organ',
-  biography: 'biography',
-  news: 'news',
-  collection: 'collection',
-  other: 'note',
-}
-
-const fmtDate = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  })
+const CATEGORY_KEYS = [
+  'travelogue',
+  'workshop',
+  'memorial',
+  'home-organ',
+  'biography',
+  'news',
+  'collection',
+  'other',
+] as const
+type CategoryKey = (typeof CATEGORY_KEYS)[number]
 
 const readMin = (excerpt: string | null) => {
   // Rough estimate from excerpt length (full content not in the
@@ -81,6 +65,7 @@ const figureLabelFor = (entry: JournalEntrySummary) => {
 }
 
 function EntryFigure({ entry }: { entry: JournalEntrySummary }) {
+  const t = useTranslations('JournalList')
   const url = entry.coverImage?.asset?._ref
     ? urlForImage(entry.coverImage)?.width(560).height(420).fit('crop').url()
     : null
@@ -107,8 +92,8 @@ function EntryFigure({ entry }: { entry: JournalEntrySummary }) {
       {entry.hasAudio && (
         <span
           className="absolute right-3 top-3 w-7 h-7 bg-[oklch(0.99_0.004_85/0.92)] text-ink rounded-full flex items-center justify-center text-sm"
-          aria-label="Has audio"
-          title="Has audio"
+          aria-label={t('hasAudio')}
+          title={t('hasAudio')}
         >
           ♪
         </span>
@@ -118,9 +103,13 @@ function EntryFigure({ entry }: { entry: JournalEntrySummary }) {
 }
 
 function EntryRow({ entry, index }: { entry: JournalEntrySummary; index: number }) {
+  const t = useTranslations('JournalList')
+  const format = useFormatter()
   const titleAttr = dataAttr({ id: entry._id, type: 'journal', path: 'title' }).toString()
-  const cat = entry.category ?? 'other'
-  const kind = CATEGORY_KIND[cat] ?? cat
+  const cat = (entry.category ?? 'other') as CategoryKey
+  const kind = (CATEGORY_KEYS as readonly string[]).includes(cat)
+    ? t(`categoryKinds.${cat}`)
+    : entry.category ?? 'other'
   return (
     <Link
       href={`/journal/${entry.slug}`}
@@ -131,7 +120,7 @@ function EntryRow({ entry, index }: { entry: JournalEntrySummary; index: number 
         <span className="block text-ink text-[11px] mb-1.5">
           N° {String(index).padStart(3, '0')}
         </span>
-        {fmtDate(entry.date)}
+        {format.dateTime(new Date(entry.date), { day: 'numeric', month: 'long', year: 'numeric' })}
         <br />
         {readMin(entry.excerpt)} min read
       </div>
@@ -152,7 +141,7 @@ function EntryRow({ entry, index }: { entry: JournalEntrySummary; index: number 
         )}
         <div className="font-mono text-[10.5px] tracking-[0.18em] uppercase text-ink-faint">
           <span className="text-ink inline-flex items-center gap-2 transition-colors duration-300 group-hover:text-accent">
-            Read entry <span className="text-[11px]">→</span>
+            {t('readEntry')} <span className="text-[11px]">→</span>
           </span>
         </div>
       </div>
@@ -162,6 +151,7 @@ function EntryRow({ entry, index }: { entry: JournalEntrySummary; index: number 
 }
 
 export function JournalList({ entries, totalCount }: JournalListProps) {
+  const t = useTranslations('JournalList')
   const [activeCat, setActiveCat] = useState<string>('all')
   const [page, setPage] = useState(1)
 
@@ -217,10 +207,10 @@ export function JournalList({ entries, totalCount }: JournalListProps) {
       <div className="max-w-[1240px] mx-auto px-6 md:px-12">
       <div className="flex flex-wrap items-center gap-x-5 gap-y-1 border-y border-rule-soft py-3.5 mb-14">
         <span className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint mr-3">
-          Filter
+          {t('filter')}
         </span>
         <FilterButton
-          label="All"
+          label={t('all')}
           count={counts.all ?? 0}
           active={activeCat === 'all'}
           onClick={() => setCat('all')}
@@ -228,21 +218,21 @@ export function JournalList({ entries, totalCount }: JournalListProps) {
         {categories.map((c) => (
           <FilterButton
             key={c}
-            label={CATEGORY_LABEL[c] ?? c}
+            label={(CATEGORY_KEYS as readonly string[]).includes(c) ? t(`categories.${c}` as never) : c}
             count={counts[c] ?? 0}
             active={activeCat === c}
             onClick={() => setCat(c)}
           />
         ))}
         <span className="ml-auto font-mono text-[10.5px] tracking-[0.18em] uppercase text-ink-faint">
-          {String(baseCount).padStart(2, '0')} entries
+          {t('entriesCount', { count: baseCount })}
         </span>
       </div>
 
       <div className="flex flex-col mb-12">
         {visible.length === 0 ? (
           <p className="font-serif italic text-ink-faint text-lg py-16 text-center">
-            Nothing in this category yet.
+            {t('emptyCategory')}
           </p>
         ) : (
           visible.map((p, i) => (
@@ -259,10 +249,10 @@ export function JournalList({ entries, totalCount }: JournalListProps) {
             disabled={safePage === 1}
             className="font-serif italic text-[18px] text-ink-soft border-b border-rule pb-[3px] transition-colors duration-200 hover:text-accent hover:border-accent disabled:opacity-50 disabled:pointer-events-none disabled:border-rule-soft cursor-pointer disabled:cursor-default bg-transparent border-x-0 border-t-0"
           >
-            ← Newer
+            {t('pagination.newer')}
           </button>
           <span className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint">
-            Page {safePage} of {totalPages}
+            {t('pagination.pageOf', { current: safePage, total: totalPages })}
           </span>
           <button
             type="button"
@@ -270,7 +260,7 @@ export function JournalList({ entries, totalCount }: JournalListProps) {
             disabled={safePage === totalPages}
             className="font-serif italic text-[18px] text-ink-soft border-b border-rule pb-[3px] transition-colors duration-200 hover:text-accent hover:border-accent disabled:opacity-50 disabled:pointer-events-none disabled:border-rule-soft cursor-pointer disabled:cursor-default bg-transparent border-x-0 border-t-0"
           >
-            Older →
+            {t('pagination.older')}
           </button>
         </div>
       )}

--- a/app/components/landing/OrganArticle.tsx
+++ b/app/components/landing/OrganArticle.tsx
@@ -1,3 +1,4 @@
+import { useFormatter, useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { Image } from 'next-sanity/image'
 import type { PortableTextBlock } from 'next-sanity'
@@ -54,13 +55,6 @@ export type OrganDetail = {
   content: PortableTextBlock[] | null
 }
 
-const fmtLong = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-GB', {
-    day: '2-digit',
-    month: 'long',
-    year: 'numeric',
-  })
-
 function readMinutes(content: PortableTextBlock[] | null): number {
   if (!content) return 0
   let words = 0
@@ -76,10 +70,11 @@ function readMinutes(content: PortableTextBlock[] | null): number {
 }
 
 function Crumbs({ city }: { city?: string }) {
+  const t = useTranslations('OrganArticle')
   return (
     <div className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint flex items-center gap-3 mb-16">
       <Link href="/" className="transition-colors hover:text-accent">
-        All organs
+        {t('breadcrumbAll')}
       </Link>
       {city && (
         <>
@@ -110,6 +105,8 @@ function Header({
   date: string
   readMin: number
 }) {
+  const t = useTranslations('OrganArticle')
+  const format = useFormatter()
   const padWidth = Math.max(2, String(totalCount || position).length)
   const numLabel = `N° ${String(position).padStart(padWidth, '0')}`
   const locLabel = location ? `${location.city}, ${location.country}` : null
@@ -118,7 +115,7 @@ function Header({
     <header className="grid grid-cols-1 gap-7 mx-auto mb-12 max-w-[880px] text-center">
       <div className="inline-flex items-center justify-center gap-4 font-mono text-[10.5px] tracking-[0.32em] uppercase text-ink-faint">
         <span className="w-7 h-px bg-current opacity-50" />
-        Field note
+        {t('fieldNote')}
         <span className="text-accent">✦</span>
         {numLabel}
         <span className="w-7 h-px bg-current opacity-50" />
@@ -145,11 +142,13 @@ function Header({
       <div className="inline-flex items-center justify-center flex-wrap gap-3.5 font-mono text-[11px] tracking-[0.16em] uppercase text-ink-faint">
         {locLabel && <span data-sanity={organAttr(organId, 'location.city')}>{locLabel}</span>}
         {locLabel && <span className="w-[3px] h-[3px] bg-ink-faint rounded-full opacity-60" />}
-        <span data-sanity={organAttr(organId, 'date')}>{fmtLong(date)}</span>
+        <span data-sanity={organAttr(organId, 'date')}>
+          {format.dateTime(new Date(date), { day: '2-digit', month: 'long', year: 'numeric' })}
+        </span>
         {readMin > 0 && (
           <>
             <span className="w-[3px] h-[3px] bg-ink-faint rounded-full opacity-60" />
-            <span>{readMin} min read</span>
+            <span>{t('minRead', { count: readMin })}</span>
           </>
         )}
       </div>
@@ -218,21 +217,28 @@ function Cover({
 }
 
 function NeighborLink({ side, organ }: { side: 'prev' | 'next'; organ: NeighborOrgan }) {
+  const t = useTranslations('OrganArticle')
+  const format = useFormatter()
   if (!organ) {
     return (
       <div className={side === 'next' ? 'md:text-right' : ''}>
         <p className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-3.5">
-          {side === 'prev' ? '← Previous visit' : 'Next visit →'}
+          {side === 'prev' ? t('previousVisit') : t('nextVisit')}
         </p>
-        <p className="font-serif italic text-ink-faint m-0">— end of the journal —</p>
+        <p className="font-serif italic text-ink-faint m-0">{t('endOfJournal')}</p>
       </div>
     )
   }
-  const meta = [organ.location?.city, fmtLong(organ.date)].filter(Boolean).join(' · ')
+  const meta = [
+    organ.location?.city,
+    format.dateTime(new Date(organ.date), { day: '2-digit', month: 'long', year: 'numeric' }),
+  ]
+    .filter(Boolean)
+    .join(' · ')
   return (
     <div className={side === 'next' ? 'md:text-right' : ''}>
       <p className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-3.5">
-        {side === 'prev' ? '← Previous visit' : 'Next visit →'}
+        {side === 'prev' ? t('previousVisit') : t('nextVisit')}
       </p>
       <Link
         href={`/organs/${organ.slug}`}

--- a/app/components/landing/OrganCard.tsx
+++ b/app/components/landing/OrganCard.tsx
@@ -1,3 +1,4 @@
+import { useFormatter, useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 import { Image } from 'next-sanity/image'
 import { dataAttr, urlForImage } from '@/sanity/lib/utils'
@@ -25,13 +26,6 @@ type OrganCardProps = {
   index?: number
   totalCount?: number
 }
-
-const fmtDate = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-GB', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  })
 
 const IconAudio = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
@@ -77,6 +71,8 @@ const IconArrow = (props: React.SVGProps<SVGSVGElement>) => (
 )
 
 export function OrganCard({ organ, index = 1, totalCount }: OrganCardProps) {
+  const t = useTranslations('OrganCard')
+  const format = useFormatter()
   const padWidth = Math.max(2, String(totalCount ?? index).length)
   const hasAudio = organ.hasAudio
   const hasVideo = organ.hasVideo
@@ -92,7 +88,7 @@ export function OrganCard({ organ, index = 1, totalCount }: OrganCardProps) {
   })
 
   const locationLabel = organ.location ? `${organ.location.city}, ${organ.location.country}` : null
-  const placeholderLabel = organ.location?.building ?? 'organ photograph'
+  const placeholderLabel = organ.location?.building ?? t('placeholderLabel')
   const builderLine = [organ.builder, organ.year].filter(Boolean).join(' · ')
 
   return (
@@ -123,7 +119,7 @@ export function OrganCard({ organ, index = 1, totalCount }: OrganCardProps) {
         {hasAudio && (
           <span
             className="h-[30px] min-w-[30px] px-[9px] inline-flex items-center justify-center gap-1.5 bg-[oklch(0.99_0.004_85/0.92)] backdrop-blur-[8px] border border-[oklch(0.86_0.012_75/0.6)] rounded-full text-ink text-[10.5px]"
-            title="Audio fragment"
+            title={t('audioFragment')}
           >
             <IconAudio className="w-[13px] h-[13px]" />
           </span>
@@ -131,7 +127,7 @@ export function OrganCard({ organ, index = 1, totalCount }: OrganCardProps) {
         {hasVideo && (
           <span
             className="h-[30px] min-w-[30px] px-[9px] inline-flex items-center justify-center gap-1.5 bg-[oklch(0.99_0.004_85/0.92)] backdrop-blur-[8px] border border-[oklch(0.86_0.012_75/0.6)] rounded-full text-ink text-[10.5px]"
-            title="Video"
+            title={t('video')}
           >
             <IconVideo className="w-[13px] h-[13px]" />
           </span>
@@ -146,7 +142,13 @@ export function OrganCard({ organ, index = 1, totalCount }: OrganCardProps) {
               <span className="w-[3px] h-[3px] bg-ink-faint rounded-full opacity-70" />
             </>
           )}
-          <span>{fmtDate(organ.date)}</span>
+          <span>
+            {format.dateTime(new Date(organ.date), {
+              day: '2-digit',
+              month: 'short',
+              year: 'numeric',
+            })}
+          </span>
         </div>
         <h3
           className="font-serif font-medium text-[27px] leading-[1.16] m-0 mb-2.5 text-ink text-balance"
@@ -162,7 +164,7 @@ export function OrganCard({ organ, index = 1, totalCount }: OrganCardProps) {
             {builderLine || organ.location?.building || ''}
           </span>
           <span className="text-ink inline-flex items-center gap-1.5 transition-colors duration-300 font-sans tracking-[0.04em] text-xs whitespace-nowrap group-hover:text-accent">
-            Read&nbsp;more
+            {t('readMore')}
             <IconArrow className="w-[14px] h-[14px]" />
           </span>
         </div>

--- a/app/components/landing/OrgansArchive.tsx
+++ b/app/components/landing/OrgansArchive.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 
 import { OrganCard, type LandingOrgan } from './OrganCard'
@@ -18,6 +19,7 @@ type OrgansArchiveProps = {
 }
 
 export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: OrgansArchiveProps) {
+  const t = useTranslations('OrgansArchive')
   const [organs, setOrgans] = useState<LandingOrgan[]>(initialOrgans)
   const [loading, setLoading] = useState(false)
   const [exhausted, setExhausted] = useState(initialOrgans.length >= totalCount)
@@ -104,13 +106,13 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
           {!exhausted && (
             <div ref={sentinelRef} className="mt-12 flex justify-center" aria-hidden="true">
               <span className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint">
-                {loading ? 'Loading…' : ''}
+                {loading ? t('loading') : ''}
               </span>
             </div>
           )}
           {exhausted && organs.length > PAGE_SIZE && (
             <p className="mt-14 text-center font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint">
-              — end of the archive —
+              {t('endOfArchive')}
             </p>
           )}
         </div>
@@ -118,7 +120,7 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
         {sortedCities.length > 0 && (
           <aside className="lg:sticky lg:top-8">
             <h3 className="font-mono font-bold text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-4 pb-3 border-b border-rule-soft">
-              By city
+              {t('byCity')}
             </h3>
             <ul className="list-none m-0 p-0 flex flex-col">
               {sortedCities.map(({ city: c, count }) => {
@@ -146,7 +148,7 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
                 href={cityHref('')}
                 className="text-ink-soft border-b border-rule pb-[3px] transition-colors duration-200 hover:text-accent hover:border-accent"
               >
-                Browse all &nbsp;→
+                {t('browseAll')}
               </Link>
             </div>
           </aside>
@@ -167,30 +169,29 @@ function ArchiveHeader({
   shown: number
   total: number
 }) {
+  const t = useTranslations('OrgansArchive')
   return (
     <div className="flex items-baseline justify-between mb-8 px-1 gap-6">
       <h2
         className="font-serif italic text-[22px] m-0 text-ink-soft"
         style={{ letterSpacing: '0.005em' }}
       >
-        {filterActive ? (
-          <>
-            Visits in <span className="not-italic font-normal text-ink">{city}</span>
-          </>
-        ) : (
-          'The archive'
-        )}
+        {filterActive
+          ? t.rich('filteredTitle', {
+              city: () => (
+                <span className="not-italic font-normal text-ink">{city}</span>
+              ),
+            })
+          : t('title')}
       </h2>
       <span className="font-mono text-[11px] tracking-[0.22em] uppercase text-ink-faint flex items-center gap-3 whitespace-nowrap">
-        <span>
-          {shown} of {total}
-        </span>
+        <span>{t('shownOfTotal', { shown, total })}</span>
         {filterActive && (
           <Link
             href={cityHref('')}
             className="text-ink-soft border-b border-rule pb-[2px] transition-colors duration-200 hover:text-accent hover:border-accent"
           >
-            clear filter ✕
+            {t('clearFilter')}
           </Link>
         )}
       </span>

--- a/app/components/landing/Privacy.tsx
+++ b/app/components/landing/Privacy.tsx
@@ -1,3 +1,4 @@
+import { useFormatter, useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 
 import { stegaAttrFor } from '@/sanity/lib/stegaFactory'
@@ -19,26 +20,40 @@ export type PrivacyContent = {
   contactLine: string | null
 }
 
-const fmtDate = (iso: string) =>
-  new Date(iso).toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  })
+function PrivacyLastUpdated({ attr, date }: { attr: string; date: string }) {
+  const t = useTranslations('Privacy')
+  const format = useFormatter()
+  return (
+    <p
+      data-sanity={attr}
+      className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-10"
+    >
+      {t('lastUpdated', {
+        date: format.dateTime(new Date(date), {
+          day: 'numeric',
+          month: 'long',
+          year: 'numeric',
+        }),
+      })}
+    </p>
+  )
+}
 
 function Crumbs() {
+  const tCrumbs = useTranslations('Crumbs')
   return (
     <div className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint flex items-center gap-3 mb-14">
       <Link href="/" className="transition-colors hover:text-accent">
-        Home
+        {tCrumbs('home')}
       </Link>
       <span className="opacity-40">/</span>
-      <span className="text-ink">Privacy</span>
+      <span className="text-ink">{tCrumbs('privacy')}</span>
     </div>
   )
 }
 
 function EmptyState() {
+  const t = useTranslations('Privacy')
   return (
     <section className="max-w-[840px] mx-auto px-6 md:px-12 py-32 text-center">
       <Crumbs />
@@ -46,14 +61,17 @@ function EmptyState() {
         className="font-serif font-light leading-none m-0 mb-8 text-balance"
         style={{ fontSize: 'clamp(40px, 5vw, 64px)', letterSpacing: '-0.012em' }}
       >
-        Privacy
+        {t('emptyTitle')}
       </h1>
       <p className="font-serif italic text-2xl text-ink-soft m-0 mb-4 max-w-[40ch] mx-auto">
-        Deze pagina is nog niet ingericht in de Studio.
+        {t('emptyBody')}
       </p>
       <p className="font-serif italic text-lg text-ink-faint m-0 max-w-[50ch] mx-auto">
-        Open <span className="not-italic font-mono text-sm text-ink">/admin → Privacy page</span>{' '}
-        om de inhoud toe te voegen.
+        {t.rich('emptyHint', {
+          code: (chunks) => (
+            <span className="not-italic font-mono text-sm text-ink">{chunks}</span>
+          ),
+        })}
       </p>
     </section>
   )
@@ -97,12 +115,10 @@ export function Privacy({
       </h1>
 
       {data.lastUpdated && (
-        <p
-          data-sanity={privacyAttr('lastUpdated')}
-          className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-10"
-        >
-          Last updated {fmtDate(data.lastUpdated)}
-        </p>
+        <PrivacyLastUpdated
+          attr={privacyAttr('lastUpdated')}
+          date={data.lastUpdated}
+        />
       )}
 
       {data.intro && (

--- a/app/components/landing/Scores.tsx
+++ b/app/components/landing/Scores.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo, useState } from 'react'
+import { useTranslations } from 'next-intl'
 import { Link } from '@/i18n/navigation'
 
 import { dataAttr } from '@/sanity/lib/utils'
@@ -37,33 +38,13 @@ type ScoresProps = {
   } | null
 }
 
-const ERA_LABELS = {
-  baroque: 'Baroque',
-  dutch: 'Dutch School',
-  romantic: 'Romantic',
-  modern: 'Modern',
-  arrangement: 'Arrangement',
-} as const
-
-type EraKey = keyof typeof ERA_LABELS
+const ERA_KEYS = ['baroque', 'dutch', 'romantic', 'modern', 'arrangement'] as const
+type EraKey = (typeof ERA_KEYS)[number]
 type FilterKey = 'all' | EraKey
 type SortKey = 'composer' | 'year' | 'edition'
 
-const FILTER_ORDER: FilterKey[] = ['all', 'baroque', 'dutch', 'romantic', 'modern', 'arrangement']
-const FILTER_LABEL: Record<FilterKey, string> = {
-  all: 'All',
-  baroque: 'Baroque',
-  dutch: 'Dutch School',
-  romantic: 'Romantic',
-  modern: 'Modern',
-  arrangement: 'Arrangements',
-}
-
-const SORTS: { key: SortKey; label: string }[] = [
-  { key: 'composer', label: 'Composer' },
-  { key: 'year', label: 'Year' },
-  { key: 'edition', label: 'Edition №' },
-]
+const FILTER_ORDER: FilterKey[] = ['all', ...ERA_KEYS]
+const SORT_KEYS: SortKey[] = ['composer', 'year', 'edition']
 
 const IconDownload = () => (
   <svg
@@ -104,17 +85,25 @@ const scoreAttr = (id: string, path: string) =>
 
 const fmtEdition = (n: number) => `Ed. Webbink · No. ${String(n).padStart(2, '0')}`
 const fmtEditionShort = (n: number) => `Ed. Webbink · No. ${String(n).padStart(2, '0')}`
-const eraLabel = (era: string | null) =>
-  (era && (ERA_LABELS as Record<string, string>)[era]) || era || ''
+
+function useEraLabel(): (era: string | null) => string {
+  const t = useTranslations('Scores.filters')
+  return (era) => {
+    if (!era) return ''
+    if ((ERA_KEYS as readonly string[]).includes(era)) return t(era as never)
+    return era
+  }
+}
 
 function Crumbs() {
+  const t = useTranslations('Crumbs')
   return (
     <div className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint flex items-center gap-3 mb-14">
       <Link href="/" className="transition-colors hover:text-accent">
-        Home
+        {t('home')}
       </Link>
       <span className="opacity-40">/</span>
-      <span className="text-ink">Scores</span>
+      <span className="text-ink">{t('scores')}</span>
     </div>
   )
 }
@@ -126,11 +115,10 @@ function Header({
   copy?: ScoresProps['copy']
   scoresPageAttr: (path: string) => string
 }) {
-  const kicker = copy?.kicker ?? 'A small library'
-  const heading = copy?.heading ?? 'Editions, fingerings, {{working scores}}.'
-  const tagline =
-    copy?.tagline ??
-    "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study."
+  const t = useTranslations('Scores')
+  const kicker = copy?.kicker ?? t('headerKickerFallback')
+  const heading = copy?.heading ?? t('headerHeadingFallback')
+  const tagline = copy?.tagline ?? t('headerTaglineFallback')
   return (
     <>
       <Crumbs />
@@ -171,7 +159,8 @@ function Toolbar({
   sortKey: SortKey
   cycleSort: () => void
 }) {
-  const sortLabel = SORTS.find((s) => s.key === sortKey)?.label ?? 'Composer'
+  const t = useTranslations('Scores')
+  const sortLabel = t(`sortBy.${sortKey}` as never)
   return (
     <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 pb-7 mb-9 border-b border-rule-soft">
       <div className="flex flex-wrap gap-1">
@@ -183,17 +172,15 @@ function Toolbar({
             data-active={active === id}
             onClick={() => setActive(id)}
           >
-            {FILTER_LABEL[id]}
+            {t(`filters.${id}` as never)}
             <span className="count">/ {counts[id] ?? 0}</span>
           </button>
         ))}
       </div>
       <div className="flex items-center gap-3.5 font-mono text-[11px] tracking-[0.18em] uppercase text-ink-faint">
-        <span>
-          <span className="text-ink">{total}</span> editions
-        </span>
+        <span>{t('editionsCount', { count: total })}</span>
         <button type="button" className="sort-btn" onClick={cycleSort}>
-          Sort: {sortLabel} <IconCaret />
+          {t('sort', { label: sortLabel })} <IconCaret />
         </button>
       </div>
     </div>
@@ -236,6 +223,8 @@ function ScoreCoverFeatured({ score }: { score: Score }) {
 }
 
 function Featured({ score }: { score: Score }) {
+  const t = useTranslations('Scores')
+  const eraLabel = useEraLabel()
   const composerAttr = scoreAttr(score._id, 'composer')
   const workAttr = scoreAttr(score._id, 'work')
   const blurbAttr = scoreAttr(score._id, 'blurb')
@@ -258,7 +247,10 @@ function Featured({ score }: { score: Score }) {
           className="font-mono text-[10.5px] tracking-[0.32em] uppercase text-accent m-0 mb-[18px] flex items-center gap-3"
         >
           <span className="w-7 h-px bg-current opacity-60" />
-          Featured edition · <span data-sanity={editionNumAttr}>No. {String(score.editionNumber).padStart(2, '0')}</span>
+          {t('featuredHeader')} ·{' '}
+          <span data-sanity={editionNumAttr}>
+            {t('editionNumber', { number: String(score.editionNumber).padStart(2, '0') })}
+          </span>
         </p>
         <h2
           className="font-serif font-light text-balance m-0 mb-5"
@@ -285,10 +277,10 @@ function Featured({ score }: { score: Score }) {
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-y-[18px] gap-x-9 mb-7 pb-5 border-b border-rule-soft">
           {(
             [
-              ['Catalog', score.catalog, 'catalog'],
-              ['Period', periodLabel || null, 'era'],
-              ['Pages', score.pages ? String(score.pages) : null, 'pages'],
-              ['Edition', score.edition, 'edition'],
+              [t('meta.catalog'), score.catalog, 'catalog'],
+              [t('meta.period'), periodLabel || null, 'era'],
+              [t('meta.pages'), score.pages ? String(score.pages) : null, 'pages'],
+              [t('meta.edition'), score.edition, 'edition'],
             ] as const
           ).map(([k, v, field]) =>
             v ? (
@@ -310,11 +302,11 @@ function Featured({ score }: { score: Score }) {
               rel="noopener noreferrer"
               className="action-btn no-underline"
             >
-              <IconDownload /> Download PDF
+              <IconDownload /> {t('downloadPdf')}
             </a>
           ) : (
             <span className="action-btn ghost opacity-60 cursor-not-allowed">
-              <IconDownload /> No PDF yet
+              <IconDownload /> {t('noPdfYet')}
             </span>
           )}
         </div>
@@ -324,6 +316,8 @@ function Featured({ score }: { score: Score }) {
 }
 
 function ScoreCard({ score }: { score: Score }) {
+  const t = useTranslations('Scores')
+  const eraLabel = useEraLabel()
   return (
     <a
       href={score.pdfUrl ?? undefined}
@@ -402,7 +396,7 @@ function ScoreCard({ score }: { score: Score }) {
           <span>
             {score.pages != null && (
               <span data-sanity={scoreAttr(score._id, 'pages')}>
-                {`${score.pages} pp`}
+                {t('pagesShort', { count: score.pages })}
               </span>
             )}
             {score.pages == null && '—'}
@@ -417,7 +411,7 @@ function ScoreCard({ score }: { score: Score }) {
             data-sanity={scoreAttr(score._id, 'pdfFile')}
             className="text-ink inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-accent"
           >
-            <IconDownload /> {score.pdfUrl ? 'PDF' : 'soon'}
+            <IconDownload /> {score.pdfUrl ? t('pdfTag') : t('comingSoon')}
           </span>
         </div>
       </div>
@@ -426,19 +420,22 @@ function ScoreCard({ score }: { score: Score }) {
 }
 
 function Grid({ scores, total }: { scores: Score[]; total: number }) {
+  const t = useTranslations('Scores')
   return (
     <section data-screen-label="grid">
       <div className="flex items-baseline justify-between gap-6 mb-7">
         <h3 className="font-serif font-normal text-3xl m-0" style={{ letterSpacing: '-0.005em' }}>
-          The <em className="italic">library</em>
+          {t.rich('libraryHeading', {
+            em: (chunks) => <em className="italic">{chunks}</em>,
+          })}
         </h3>
         <span className="font-mono text-[10.5px] tracking-[0.18em] uppercase text-ink-faint">
-          Showing {scores.length} of {total}
+          {t('showing', { shown: scores.length, total })}
         </span>
       </div>
       {scores.length === 0 ? (
         <p className="font-serif italic text-ink-faint text-lg pb-24">
-          Nothing in this category yet — try another filter.
+          {t('emptyFilter')}
         </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-y-9 gap-x-8 pb-24">
@@ -473,10 +470,9 @@ function Notice({
     type: 'settings',
     path: 'scoresEditionLine',
   }).toString()
-  const text =
-    body ??
-    'These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.'
-  const editionPrefix = editionLine ?? 'Edition Webbink'
+  const t = useTranslations('Scores')
+  const text = body ?? t('noticeBodyFallback')
+  const editionPrefix = editionLine ?? t('noticeEditionLineFallback')
   const href = contactHref ?? 'mailto:bert@webbink.nl'
   return (
     <section
@@ -502,20 +498,21 @@ function Notice({
         </small>
       </div>
       <a className="action-btn ghost not-italic no-underline" href={href}>
-        Write to me
+        {t('writeToMe')}
       </a>
     </section>
   )
 }
 
 function EmptyLibrary() {
+  const t = useTranslations('Scores')
   return (
     <section className="pt-2 pb-24 text-center">
       <p className="font-serif italic text-2xl text-ink-soft m-0 mb-4 max-w-[40ch] mx-auto">
-        The library is just being set up.
+        {t('emptyTitle')}
       </p>
       <p className="font-serif italic text-lg text-ink-faint m-0 max-w-[50ch] mx-auto">
-        Editions will appear here as I prepare them. Check back, or write to me below.
+        {t('emptyBody')}
       </p>
     </section>
   )
@@ -524,7 +521,7 @@ function EmptyLibrary() {
 export function Scores({ locale, scores, copy }: ScoresProps) {
   const [active, setActive] = useState<FilterKey>('all')
   const [sortIdx, setSortIdx] = useState(0)
-  const sortKey = SORTS[sortIdx].key
+  const sortKey = SORT_KEYS[sortIdx]
   const scoresPageAttr = makeScoresPageAttr(locale)
 
   const counts = useMemo(() => {
@@ -559,7 +556,7 @@ export function Scores({ locale, scores, copy }: ScoresProps) {
     })
   }, [scores, active, sortKey])
 
-  const cycleSort = () => setSortIdx((i) => (i + 1) % SORTS.length)
+  const cycleSort = () => setSortIdx((i) => (i + 1) % SORT_KEYS.length)
 
   return (
     <>

--- a/app/components/landing/Specs.tsx
+++ b/app/components/landing/Specs.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from 'next-intl'
+
 import { dataAttr } from '@/sanity/lib/utils'
 
 const organAttr = (id: string, path: string) =>
@@ -97,29 +99,30 @@ function NamedList({
 }
 
 export function Specs({ organId, builder, year, disposition }: SpecsProps) {
+  const t = useTranslations('Specs')
   const d: Disposition = disposition ?? {}
   const dispAttr = (path: string) =>
     organId ? organAttr(organId, `disposition.${path}`) : undefined
   const stats: { key: string; label: string; value: string; field: string }[] = []
   if (d.manuals != null)
-    stats.push({ key: 'manuals', label: 'Manuals', value: String(d.manuals), field: 'manuals' })
+    stats.push({ key: 'manuals', label: t('manuals'), value: String(d.manuals), field: 'manuals' })
   if (d.stops != null)
-    stats.push({ key: 'stops', label: 'Stops', value: String(d.stops), field: 'stops' })
+    stats.push({ key: 'stops', label: t('stops'), value: String(d.stops), field: 'stops' })
   if (d.pitch)
-    stats.push({ key: 'pitch', label: 'Pitch', value: d.pitch, field: 'pitch' })
+    stats.push({ key: 'pitch', label: t('pitch'), value: d.pitch, field: 'pitch' })
   if (d.temperament)
     stats.push({
       key: 'temperament',
-      label: 'Temperament',
+      label: t('temperament'),
       value: d.temperament,
       field: 'temperament',
     })
   if (d.action)
-    stats.push({ key: 'action', label: 'Action', value: d.action, field: 'action' })
+    stats.push({ key: 'action', label: t('action'), value: d.action, field: 'action' })
 
   const builtLine = [
-    year ? `Built ${year}` : null,
-    d.restoredYear ? `Restored ${d.restoredYear}` : null,
+    year ? t('built', { year }) : null,
+    d.restoredYear ? t('restored', { year: d.restoredYear }) : null,
   ]
     .filter(Boolean)
     .join(' · ')
@@ -127,7 +130,7 @@ export function Specs({ organId, builder, year, disposition }: SpecsProps) {
   return (
     <aside className="lg:sticky lg:top-8">
       <h3 className="font-mono text-[10.5px] tracking-[0.22em] uppercase text-ink-faint m-0 mb-4 pb-3 border-b border-rule-soft">
-        Specification
+        {t('specification')}
       </h3>
       {builder && (
         <p
@@ -224,7 +227,7 @@ export function Specs({ organId, builder, year, disposition }: SpecsProps) {
           })}
           {d.couplings && d.couplings.length > 0 && (
             <NamedList
-              title="Couplings"
+              title={t('couplings')}
               items={d.couplings as NamedItem[]}
               organId={organId}
               field="couplings"
@@ -232,7 +235,7 @@ export function Specs({ organId, builder, year, disposition }: SpecsProps) {
           )}
           {d.accessories && d.accessories.length > 0 && (
             <NamedList
-              title="Accessories"
+              title={t('accessories')}
               items={d.accessories as NamedItem[]}
               organId={organId}
               field="accessories"

--- a/core/translator/gemini.ts
+++ b/core/translator/gemini.ts
@@ -31,7 +31,10 @@ export class GeminiTranslator implements Translator {
     const apiKey = opts?.apiKey ?? process.env.GOOGLE_AI_API_KEY ?? process.env.GEMINI_API_KEY
     if (!apiKey) throw new Error('GeminiTranslator: missing GOOGLE_AI_API_KEY / GEMINI_API_KEY')
     this.apiKey = apiKey
-    this.model = opts?.model ?? process.env.GEMINI_MODEL ?? 'gemini-2.5-pro'
+    // Default to 2.5 Flash for cost — ~33× cheaper on output than 2.5 Pro,
+    // and quality is fine for our shape of work. Override per call via
+    // `GEMINI_MODEL` or constructor opts.
+    this.model = opts?.model ?? process.env.GEMINI_MODEL ?? 'gemini-2.5-flash'
     this.baseUrl =
       opts?.baseUrl ?? 'https://generativelanguage.googleapis.com/v1beta'
   }

--- a/core/translator/orchestrator.ts
+++ b/core/translator/orchestrator.ts
@@ -3,6 +3,7 @@ import type { SanityClient } from '@sanity/client'
 import { LOCALES, type Locale } from '@/core/i18n/locales'
 
 import { combineTranslations, diffUnits } from './diff'
+import { applyTranslatedSlug } from './slug'
 import type { Translator } from './types'
 import { applyAll, extractAll } from './walkers/registry'
 
@@ -206,9 +207,13 @@ async function translateDocPerLocale(
     : (previousSiblingId ?? `${sourceType}-${target}-${cryptoRandomShort()}`)
 
   // Build the target doc body: start from a deep clone of the source,
-  // apply translations, swap language + id + provenance.
+  // apply translations, swap language + id + provenance, derive slug.
   const baseDoc = applyAll(sourceDoc, sourceType, finalUnits, target) as Record<string, unknown>
-  const targetDoc: Record<string, unknown> = stripSystemFields(baseDoc)
+  const slugged =
+    sourceType === 'journal' || sourceType === 'organ'
+      ? applyTranslatedSlug(baseDoc, previousSibling, finalUnits)
+      : baseDoc
+  const targetDoc: Record<string, unknown> = stripSystemFields(slugged)
   targetDoc._id = targetId
   targetDoc._type = sourceType
   targetDoc.language = target

--- a/core/translator/slug.spec.ts
+++ b/core/translator/slug.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyTranslatedSlug, nextSlugForTranslation, slugify } from './slug'
+
+describe('slugify', () => {
+  it('lowercases and replaces whitespace with dashes', () => {
+    expect(slugify('Hello World')).toBe('hello-world')
+  })
+
+  it('strips diacritics from latin text', () => {
+    expect(slugify('café')).toBe('cafe')
+    expect(slugify('naïve résumé')).toBe('naive-resume')
+  })
+
+  it('keeps CJK characters intact', () => {
+    expect(slugify('日本語のタイトル')).toBe('日本語のタイトル')
+  })
+
+  it('removes punctuation and trims dashes', () => {
+    expect(slugify('  -- A title? -- ')).toBe('a-title')
+  })
+
+  it('caps long output at 96 chars', () => {
+    const long = 'a'.repeat(200)
+    expect(slugify(long).length).toBe(96)
+  })
+})
+
+describe('nextSlugForTranslation', () => {
+  it('derives a fresh slug when there is no previous slug', () => {
+    expect(
+      nextSlugForTranslation({ newTranslatedTitle: 'Hello World' }),
+    ).toBe('hello-world')
+  })
+
+  it('refreshes when the previous slug looks machine-generated', () => {
+    expect(
+      nextSlugForTranslation({
+        newTranslatedTitle: 'New Title',
+        previousTranslatedTitle: 'Old Title',
+        existingSlug: 'old-title',
+      }),
+    ).toBe('new-title')
+  })
+
+  it('preserves a manual override when the existing slug differs from the auto value', () => {
+    expect(
+      nextSlugForTranslation({
+        newTranslatedTitle: 'New Title',
+        previousTranslatedTitle: 'Old Title',
+        existingSlug: 'editor-pinned',
+      }),
+    ).toBeNull()
+  })
+
+  it('leaves the slug alone when no previous title is known', () => {
+    expect(
+      nextSlugForTranslation({
+        newTranslatedTitle: 'New Title',
+        existingSlug: 'whatever',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null when both new title and existing slug are empty', () => {
+    expect(nextSlugForTranslation({ newTranslatedTitle: '   ' })).toBeNull()
+  })
+
+  it('returns null when the new title slugifies to empty even with a refresh path', () => {
+    expect(
+      nextSlugForTranslation({
+        newTranslatedTitle: '   ',
+        previousTranslatedTitle: 'Old Title',
+        existingSlug: 'old-title',
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('applyTranslatedSlug', () => {
+  it('returns the input doc unchanged when no title unit is present', () => {
+    const doc = { title: 'A', slug: { _type: 'slug', current: 'a' } }
+    expect(applyTranslatedSlug(doc, undefined, [])).toBe(doc)
+  })
+
+  it('writes a fresh slug when the previous sibling slug matches the auto value', () => {
+    const doc = { title: '[en] Nieuw', slug: { _type: 'slug', current: 'nieuw' } }
+    const prev = { title: 'Nieuw', slug: { _type: 'slug', current: 'nieuw' } }
+    const result = applyTranslatedSlug(doc, prev, [
+      { id: 'title', sourceText: '[en] Nieuw' },
+    ])
+    const slug = (result as { slug: { current: string } }).slug
+    expect(slug.current).toBe('en-nieuw')
+  })
+
+  it('keeps a manual slug when previous sibling slug diverges from auto', () => {
+    const doc = { title: '[en] Nieuw' }
+    const prev = { title: 'Nieuw', slug: { _type: 'slug', current: 'editor-pinned' } }
+    const result = applyTranslatedSlug(doc, prev, [
+      { id: 'title', sourceText: '[en] Nieuw' },
+    ])
+    expect((result as { slug?: { current?: string } }).slug).toBeUndefined()
+  })
+})

--- a/core/translator/slug.ts
+++ b/core/translator/slug.ts
@@ -1,0 +1,80 @@
+import type { TranslationUnit } from './types'
+
+type AnyDoc = Record<string, unknown>
+
+const SLUG_PATHS = ['slug.current'] as const
+
+/**
+ * URL-safe transliteration of a translated title. Lowercase ASCII,
+ * dashes between words, no leading/trailing dashes. Mirrors Sanity's
+ * default slugifier closely enough for our purposes.
+ */
+export function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .normalize('NFKD')
+    // Strip combining diacritics (CJK left intact; transliteration is best-effort).
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{L}\p{N}]+/gu, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 96)
+}
+
+/**
+ * Decide what slug a translated sibling should carry.
+ *
+ * Rules:
+ * 1. If the sibling has no slug yet, derive from the translated title.
+ * 2. If the sibling already has a slug AND it matches `slugify(previousTranslatedTitle)`,
+ *    treat it as machine-generated and refresh from the new title.
+ * 3. Otherwise treat it as a manual override and keep it untouched.
+ *
+ * Returns the new slug to write, or `null` to leave the existing slug alone.
+ */
+export function nextSlugForTranslation(args: {
+  newTranslatedTitle: string
+  previousTranslatedTitle?: string | null
+  existingSlug?: string | null
+}): string | null {
+  const { newTranslatedTitle, previousTranslatedTitle, existingSlug } = args
+  const generated = slugify(newTranslatedTitle)
+  if (!existingSlug) return generated || null
+  if (!previousTranslatedTitle) return null // can't tell if manual; keep
+  const previouslyGenerated = slugify(previousTranslatedTitle)
+  if (existingSlug === previouslyGenerated) {
+    return generated || null
+  }
+  return null
+}
+
+/**
+ * Apply slug logic in place. Mutates a deep clone of the doc.
+ * `units` carries the translated `title` if it was in the LLM output;
+ * if no title was translated this call is a no-op.
+ */
+export function applyTranslatedSlug(
+  doc: AnyDoc,
+  previousSibling: AnyDoc | undefined,
+  units: TranslationUnit[],
+): AnyDoc {
+  const titleUnit = units.find((u) => u.id === 'title')
+  if (!titleUnit) return doc
+  const previousTitle =
+    previousSibling && typeof previousSibling.title === 'string'
+      ? (previousSibling.title as string)
+      : null
+  const previousSlug =
+    previousSibling && (previousSibling.slug as { current?: string } | undefined)?.current
+  const next = nextSlugForTranslation({
+    newTranslatedTitle: titleUnit.sourceText,
+    previousTranslatedTitle: previousTitle,
+    existingSlug: previousSlug ?? null,
+  })
+  if (!next) return doc
+  return {
+    ...doc,
+    slug: { _type: 'slug', current: next },
+  }
+}
+
+export const SLUG_FIELDS = SLUG_PATHS

--- a/messages/.last-seen-en.json
+++ b/messages/.last-seen-en.json
@@ -1,0 +1,242 @@
+{
+  "Nav": {
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu",
+    "wordmarkFallback": "Bert Webbink",
+    "taglineFallback": "Organist",
+    "items": {
+      "organs": "Organs",
+      "scores": "Scores",
+      "about": "About me",
+      "elsewhere": "Elsewhere"
+    }
+  },
+  "Footer": {
+    "copyright": "© Bert Webbink, {year}",
+    "links": {
+      "privacy": "Privacy",
+      "elsewhere": "Elsewhere",
+      "contact": "Contact"
+    }
+  },
+  "Crumbs": {
+    "home": "Home",
+    "organs": "Organs",
+    "journal": "Journal",
+    "scores": "Scores",
+    "about": "About",
+    "elsewhere": "Elsewhere",
+    "privacy": "Privacy"
+  },
+  "LanguagePicker": {
+    "label": "Language",
+    "switchTo": "Switch to {language}"
+  },
+  "Metadata": {
+    "journal": {
+      "title": "Journal",
+      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+    },
+    "organs": {
+      "title": "Organs",
+      "description": "Field notes from organs visited across the Netherlands and beyond."
+    },
+    "scores": {
+      "title": "Scores",
+      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+    },
+    "about": {
+      "title": "About me",
+      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+    },
+    "elsewhere": {
+      "title": "Elsewhere",
+      "description": "Curated links — choirs, churches, organ resources."
+    },
+    "privacy": {
+      "title": "Privacy",
+      "description": "A short, plain-language note about what gets logged when you visit this site."
+    }
+  },
+  "UnderConstruction": {
+    "title": "Under construction",
+    "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
+  }
+}

--- a/messages/de.json
+++ b/messages/de.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -24,26 +24,26 @@
     "organs": "Orgeln",
     "journal": "Journal",
     "scores": "Noten",
-    "about": "Über mich",
+    "about": "Über",
     "elsewhere": "Anderswo",
     "privacy": "Datenschutz"
   },
   "LanguagePicker": {
     "label": "Sprache",
-    "switchTo": "Zu {language} wechseln"
+    "switchTo": "Wechseln zu {language}"
   },
   "Metadata": {
     "journal": {
       "title": "Journal",
-      "description": "Essays, Fragmente, unfertige Gedanken – veröffentlicht, wenn es etwas zu sagen gibt."
+      "description": "Essays, Fragmente, halbfertige Gedanken – veröffentlicht, wenn es etwas zu sagen gibt."
     },
     "organs": {
       "title": "Orgeln",
-      "description": "Aufzeichnungen von Orgelbesuchen in den Niederlanden und darüber hinaus."
+      "description": "Feldnotizen von Orgeln, die in den Niederlanden und darüber hinaus besucht wurden."
     },
     "scores": {
       "title": "Noten",
-      "description": "Arbeitsausgaben von Orgelnoten, erstellt von Bert Webbink – Fingersätze, Registrierungen, kostenlos zum Download für nicht-kommerzielle Studien."
+      "description": "Arbeitsausgaben von Orgelnoten, erstellt von Bert Webbink – Fingersätze, Registrierungen, kostenlos zum nicht-kommerziellen Studium herunterladbar."
     },
     "about": {
       "title": "Über mich",
@@ -55,18 +55,18 @@
     },
     "privacy": {
       "title": "Datenschutz",
-      "description": "Eine kurze, verständliche Erläuterung, was beim Besuch dieser Website protokolliert wird."
+      "description": "Eine kurze, verständliche Notiz darüber, was beim Besuch dieser Website protokolliert wird."
     }
   },
   "UnderConstruction": {
     "title": "Im Aufbau",
-    "subtitle": "Schauen Sie bald wieder vorbei."
+    "subtitle": "Bald wiederkommen."
   },
   "Hero": {
     "kickerLeftFallback": "Feldnotizen",
     "kickerRightFallback": "Von der Orgelempore",
     "headingFallback": "Besuche bei {{alten Orgeln}}",
-    "taglineFallback": "Aufnahmen, Fotos und Register, gesammelt an Samstagen in den Niederlanden und darüber hinaus.",
+    "taglineFallback": "Aufnahmen, Fotografien und Register von jeweils einem Samstag, gesammelt in den Niederlanden und darüber hinaus.",
     "cornerLeftSubFallback": "Ein Feldjournal",
     "cornerRightSubFallback": "Die Niederlande",
     "stats": "Seit {firstYear} · {totalCount} Orgeln"
@@ -75,7 +75,7 @@
     "kickerLeftFallback": "Schriften",
     "kickerRightFallback": "Ein Feldjournal",
     "headingFallback": "Das {{Journal}}",
-    "taglineFallback": "Essays, Fragmente, unfertige Gedanken – veröffentlicht, wenn es etwas zu sagen gibt, meist nachdem eine Orgelbank meine Meinung über etwas geändert hat.",
+    "taglineFallback": "Essays, Fragmente, halbfertige Gedanken – veröffentlicht, wenn es etwas zu sagen gibt, meist nachdem eine Bank meine Meinung zu etwas geändert hat.",
     "cornerLeftSubFallback": "Notizen zwischen Besuchen",
     "cornerRightSubFallback": "Die Niederlande",
     "stats": "Seit {firstYear} · {totalCount} Einträge"
@@ -84,28 +84,28 @@
     "title": "Das Archiv",
     "filteredTitle": "Besuche in <city>{city}</city>",
     "byCity": "Nach Stadt",
-    "browseAll": "Alle ansehen →",
+    "browseAll": "Alle durchsuchen →",
     "shownOfTotal": "{shown} von {total}",
     "clearFilter": "Filter löschen ✕",
-    "loading": "Wird geladen …",
+    "loading": "Lädt…",
     "endOfArchive": "— Ende des Archivs —"
   },
   "OrganCard": {
-    "readMore": "Weiterlesen",
-    "audioFragment": "Hörbeispiel",
+    "readMore": "Mehr lesen",
+    "audioFragment": "Audiofragment",
     "video": "Video",
-    "placeholderLabel": "Orgelfoto"
+    "placeholderLabel": "Orgelaufnahme"
   },
   "JournalList": {
     "filter": "Filter",
     "all": "Alle",
     "categories": {
       "travelogue": "Reise",
-      "workshop": "Werkstatt",
+      "workshop": "Workshop",
       "memorial": "Gedenken",
       "home-organ": "Hausorgel",
       "biography": "Biografie",
-      "news": "Aktuelles",
+      "news": "Nachrichten",
       "collection": "Sammlung",
       "other": "Sonstiges"
     },
@@ -115,15 +115,15 @@
       "memorial": "Gedenken",
       "home-organ": "Hausorgel",
       "biography": "Biografie",
-      "news": "Aktuelles",
+      "news": "Nachrichten",
       "collection": "Sammlung",
       "other": "Notiz"
     },
     "entriesCount": "{count, plural, one {# Eintrag} other {# Einträge}}",
     "emptyCategory": "Noch nichts in dieser Kategorie.",
     "pagination": {
-      "newer": "← Neuer",
-      "older": "Älter →",
+      "newer": "← Neuere",
+      "older": "Ältere →",
       "pageOf": "Seite {current} von {total}"
     },
     "hasAudio": "Mit Audio",
@@ -131,15 +131,15 @@
     "minRead": "{count, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}"
   },
   "Specs": {
-    "specification": "Disposition",
-    "manuals": "Manuale",
+    "specification": "Spezifikation",
+    "manuals": "Manualen",
     "stops": "Register",
-    "pitch": "Stimmungshöhe",
+    "pitch": "Stimmung",
     "temperament": "Temperatur",
     "action": "Traktur",
     "couplings": "Koppeln",
-    "accessories": "Spielhilfen",
-    "built": "Erbaut {year}",
+    "accessories": "Zubehör",
+    "built": "Gebaut {year}",
     "restored": "Restauriert {year}"
   },
   "Scores": {
@@ -148,26 +148,26 @@
       "baroque": "Barock",
       "dutch": "Niederländische Schule",
       "romantic": "Romantik",
-      "modern": "Moderne",
+      "modern": "Modern",
       "arrangement": "Bearbeitungen"
     },
     "sortBy": {
       "composer": "Komponist",
       "year": "Jahr",
-      "edition": "Ausgabe №"
+      "edition": "Ausgabe Nr."
     },
     "headerKickerFallback": "Eine kleine Bibliothek",
     "headerHeadingFallback": "Ausgaben, Fingersätze, {{Arbeitsnoten}}.",
-    "headerTaglineFallback": "Arbeitsausgaben, die ich für meinen eigenen Gebrauch vorbereitet habe – die meisten für bestimmte Instrumente, die in den Feldnotizen besucht wurden. Fingersätze und Registrierungen sind Vorschläge, keine Vorschriften. Alle Noten stehen zum kostenlosen Download für nicht-kommerzielle Studienzwecke zur Verfügung.",
-    "noticeBodyFallback": "Diese Noten sind für das persönliche Studium und den kirchlichen Gebrauch bestimmt. Wenn Sie ein Werk aufführen oder aufnehmen möchten, freue ich mich über eine kurze E-Mail – und bitte geben Sie die Ausgabe an.",
+    "headerTaglineFallback": "Arbeitsausgaben, die ich für den Eigengebrauch erstellt habe – die meisten für bestimmte Instrumente, die in den Feldnotizen besucht wurden. Fingersätze und Registrierungen sind Vorschläge, keine Vorschriften. Alle Noten können kostenlos für nicht-kommerzielle Studien heruntergeladen werden.",
+    "noticeBodyFallback": "Diese Noten werden für das persönliche Studium und den kirchlichen Gebrauch geteilt. Wenn Sie eine aufführen oder aufnehmen möchten, ist eine kurze E-Mail willkommen – und bitte geben Sie die Ausgabe an.",
     "noticeEditionLineFallback": "Edition Webbink",
     "writeToMe": "Schreiben Sie mir",
     "emptyTitle": "Die Bibliothek wird gerade eingerichtet.",
-    "emptyBody": "Ausgaben werden hier erscheinen, sobald ich sie vorbereite. Schauen Sie wieder vorbei oder schreiben Sie mir unten.",
+    "emptyBody": "Ausgaben werden hier erscheinen, sobald ich sie vorbereitet habe. Schauen Sie wieder vorbei oder schreiben Sie mir unten.",
     "editionsCount": "{count, plural, one {# Ausgabe} other {# Ausgaben}}",
     "sort": "Sortieren: {label}",
     "period": "Epoche",
-    "download": "Download",
+    "download": "Herunterladen",
     "feature": "Empfohlene Ausgabe",
     "featuredHeader": "Empfohlene Ausgabe",
     "editionNumber": "Nr. {number}",
@@ -184,13 +184,13 @@
     "pdfTag": "PDF",
     "comingSoon": "bald",
     "libraryHeading": "Die <em>Bibliothek</em>",
-    "showing": "{shown} von {total} angezeigt",
+    "showing": "Zeigt {shown} von {total}",
     "emptyFilter": "Noch nichts in dieser Kategorie – versuchen Sie einen anderen Filter."
   },
   "About": {
     "emptyTitle": "Über mich",
-    "emptyBody": "Diese Seite wurde im Studio noch nicht eingerichtet.",
-    "emptyHint": "Öffnen Sie <code>/admin → Seite „Über mich“</code>, um den Inhalt hinzuzufügen.",
+    "emptyBody": "Diese Seite wurde noch nicht im Studio eingerichtet.",
+    "emptyHint": "Öffnen Sie <code>/admin → About page</code>, um den Inhalt hinzuzufügen.",
     "trajectoryNum": "01",
     "trajectoryLabel": "Werdegang",
     "trajectoryHeading": "Eine kurze <em>Chronologie</em> – wie ich hierher kam.",
@@ -200,15 +200,15 @@
   },
   "Privacy": {
     "emptyTitle": "Datenschutz",
-    "emptyBody": "Diese Seite wurde im Studio noch nicht eingerichtet.",
-    "emptyHint": "Öffnen Sie <code>/admin → Seite „Datenschutz“</code>, um den Inhalt hinzuzufügen.",
+    "emptyBody": "Diese Seite wurde noch nicht im Studio eingerichtet.",
+    "emptyHint": "Öffnen Sie <code>/admin → Privacy page</code>, um den Inhalt hinzuzufügen.",
     "lastUpdated": "Zuletzt aktualisiert am {date}"
   },
   "Elsewhere": {
     "title": "Anderswo",
     "emptyTitle": "Anderswo",
-    "emptyBody": "Diese Seite wurde im Studio noch nicht eingerichtet.",
-    "emptyHint": "Öffnen Sie <code>/admin → Seite „Anderswo“</code>, um Links hinzuzufügen.",
+    "emptyBody": "Diese Seite wurde noch nicht im Studio eingerichtet.",
+    "emptyHint": "Öffnen Sie <code>/admin → Elsewhere page</code>, um Links hinzuzufügen.",
     "noLinks": "Noch keine Links."
   },
   "JournalArticle": {
@@ -219,11 +219,11 @@
     "minRead": "{count, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}",
     "categories": {
       "travelogue": "Reisebericht",
-      "workshop": "Werkstatt",
+      "workshop": "Workshop",
       "memorial": "In memoriam",
       "home-organ": "Hausorgel",
       "biography": "Biografie",
-      "news": "Aktuelles",
+      "news": "Nachrichten",
       "collection": "Sammlung",
       "other": "Feldnotiz"
     }

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
+    "openMenu": "Menü öffnen",
+    "closeMenu": "Menü schließen",
     "wordmarkFallback": "Bert Webbink",
     "taglineFallback": "Organist",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "Orgeln",
+      "scores": "Noten",
+      "about": "Über mich",
+      "elsewhere": "Anderswo"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "privacy": "Datenschutz",
+      "elsewhere": "Anderswo",
+      "contact": "Kontakt"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
+    "home": "Startseite",
+    "organs": "Orgeln",
     "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "scores": "Noten",
+    "about": "Über mich",
+    "elsewhere": "Anderswo",
+    "privacy": "Datenschutz"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "Sprache",
+    "switchTo": "Zu {language} wechseln"
   },
   "Metadata": {
     "journal": {
       "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "description": "Essays, Fragmente, unfertige Gedanken – veröffentlicht, wenn es etwas zu sagen gibt."
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "Orgeln",
+      "description": "Aufzeichnungen von Orgelbesuchen in den Niederlanden und darüber hinaus."
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "Noten",
+      "description": "Arbeitsausgaben von Orgelnoten, erstellt von Bert Webbink – Fingersätze, Registrierungen, kostenlos zum Download für nicht-kommerzielle Studien."
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "Über mich",
+      "description": "Bert Webbink – Organist, Lehrer, stiller Besucher alter Gebäude."
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "Anderswo",
+      "description": "Ausgewählte Links – Chöre, Kirchen, Orgelressourcen."
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "Datenschutz",
+      "description": "Eine kurze, verständliche Erläuterung, was beim Besuch dieser Website protokolliert wird."
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "Im Aufbau",
+    "subtitle": "Schauen Sie bald wieder vorbei."
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "Feldnotizen",
+    "kickerRightFallback": "Von der Orgelempore",
+    "headingFallback": "Besuche bei {{alten Orgeln}}",
+    "taglineFallback": "Aufnahmen, Fotos und Register, gesammelt an Samstagen in den Niederlanden und darüber hinaus.",
+    "cornerLeftSubFallback": "Ein Feldjournal",
+    "cornerRightSubFallback": "Die Niederlande",
+    "stats": "Seit {firstYear} · {totalCount} Orgeln"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "Schriften",
+    "kickerRightFallback": "Ein Feldjournal",
+    "headingFallback": "Das {{Journal}}",
+    "taglineFallback": "Essays, Fragmente, unfertige Gedanken – veröffentlicht, wenn es etwas zu sagen gibt, meist nachdem eine Orgelbank meine Meinung über etwas geändert hat.",
+    "cornerLeftSubFallback": "Notizen zwischen Besuchen",
+    "cornerRightSubFallback": "Die Niederlande",
+    "stats": "Seit {firstYear} · {totalCount} Einträge"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "Das Archiv",
+    "filteredTitle": "Besuche in <city>{city}</city>",
+    "byCity": "Nach Stadt",
+    "browseAll": "Alle ansehen →",
+    "shownOfTotal": "{shown} von {total}",
+    "clearFilter": "Filter löschen ✕",
+    "loading": "Wird geladen …",
+    "endOfArchive": "— Ende des Archivs —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
+    "readMore": "Weiterlesen",
+    "audioFragment": "Hörbeispiel",
     "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "placeholderLabel": "Orgelfoto"
   },
   "JournalList": {
     "filter": "Filter",
-    "all": "All",
+    "all": "Alle",
     "categories": {
-      "travelogue": "Travel",
-      "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "travelogue": "Reise",
+      "workshop": "Werkstatt",
+      "memorial": "Gedenken",
+      "home-organ": "Hausorgel",
+      "biography": "Biografie",
+      "news": "Aktuelles",
+      "collection": "Sammlung",
+      "other": "Sonstiges"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "Reisebericht",
+      "workshop": "Besuch",
+      "memorial": "Gedenken",
+      "home-organ": "Hausorgel",
+      "biography": "Biografie",
+      "news": "Aktuelles",
+      "collection": "Sammlung",
+      "other": "Notiz"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count, plural, one {# Eintrag} other {# Einträge}}",
+    "emptyCategory": "Noch nichts in dieser Kategorie.",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← Neuer",
+      "older": "Älter →",
+      "pageOf": "Seite {current} von {total}"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "Mit Audio",
+    "readEntry": "Eintrag lesen",
+    "minRead": "{count, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "Disposition",
+    "manuals": "Manuale",
+    "stops": "Register",
+    "pitch": "Stimmungshöhe",
+    "temperament": "Temperatur",
+    "action": "Traktur",
+    "couplings": "Koppeln",
+    "accessories": "Spielhilfen",
+    "built": "Erbaut {year}",
+    "restored": "Restauriert {year}"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "Alle",
+      "baroque": "Barock",
+      "dutch": "Niederländische Schule",
+      "romantic": "Romantik",
+      "modern": "Moderne",
+      "arrangement": "Bearbeitungen"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "Komponist",
+      "year": "Jahr",
+      "edition": "Ausgabe №"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "headerKickerFallback": "Eine kleine Bibliothek",
+    "headerHeadingFallback": "Ausgaben, Fingersätze, {{Arbeitsnoten}}.",
+    "headerTaglineFallback": "Arbeitsausgaben, die ich für meinen eigenen Gebrauch vorbereitet habe – die meisten für bestimmte Instrumente, die in den Feldnotizen besucht wurden. Fingersätze und Registrierungen sind Vorschläge, keine Vorschriften. Alle Noten stehen zum kostenlosen Download für nicht-kommerzielle Studienzwecke zur Verfügung.",
+    "noticeBodyFallback": "Diese Noten sind für das persönliche Studium und den kirchlichen Gebrauch bestimmt. Wenn Sie ein Werk aufführen oder aufnehmen möchten, freue ich mich über eine kurze E-Mail – und bitte geben Sie die Ausgabe an.",
     "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
+    "writeToMe": "Schreiben Sie mir",
+    "emptyTitle": "Die Bibliothek wird gerade eingerichtet.",
+    "emptyBody": "Ausgaben werden hier erscheinen, sobald ich sie vorbereite. Schauen Sie wieder vorbei oder schreiben Sie mir unten.",
+    "editionsCount": "{count, plural, one {# Ausgabe} other {# Ausgaben}}",
+    "sort": "Sortieren: {label}",
+    "period": "Epoche",
     "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "feature": "Empfohlene Ausgabe",
+    "featuredHeader": "Empfohlene Ausgabe",
+    "editionNumber": "Nr. {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "Katalog",
+      "period": "Epoche",
+      "pages": "Seiten",
+      "edition": "Ausgabe"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "downloadPdf": "PDF herunterladen",
+    "noPdfYet": "Noch kein PDF",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "pagesShort": "{count} S.",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "bald",
+    "libraryHeading": "Die <em>Bibliothek</em>",
+    "showing": "{shown} von {total} angezeigt",
+    "emptyFilter": "Noch nichts in dieser Kategorie – versuchen Sie einen anderen Filter."
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "Über mich",
+    "emptyBody": "Diese Seite wurde im Studio noch nicht eingerichtet.",
+    "emptyHint": "Öffnen Sie <code>/admin → Seite „Über mich“</code>, um den Inhalt hinzuzufügen.",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "Werdegang",
+    "trajectoryHeading": "Eine kurze <em>Chronologie</em> – wie ich hierher kam.",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "Was ich spiele",
+    "repertoireHeading": "Repertoire, zu dem ich immer wieder <em>zurückkehre</em>."
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "Datenschutz",
+    "emptyBody": "Diese Seite wurde im Studio noch nicht eingerichtet.",
+    "emptyHint": "Öffnen Sie <code>/admin → Seite „Datenschutz“</code>, um den Inhalt hinzuzufügen.",
+    "lastUpdated": "Zuletzt aktualisiert am {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "Anderswo",
+    "emptyTitle": "Anderswo",
+    "emptyBody": "Diese Seite wurde im Studio noch nicht eingerichtet.",
+    "emptyHint": "Öffnen Sie <code>/admin → Seite „Anderswo“</code>, um Links hinzuzufügen.",
+    "noLinks": "Noch keine Links."
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "Das Journal",
+    "previousEntry": "← Vorheriger Eintrag",
+    "nextEntry": "Nächster Eintrag →",
+    "endOfJournal": "— Ende des Journals —",
+    "minRead": "{count, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}",
     "categories": {
-      "travelogue": "Travelogue",
-      "workshop": "Workshop",
+      "travelogue": "Reisebericht",
+      "workshop": "Werkstatt",
       "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "home-organ": "Hausorgel",
+      "biography": "Biografie",
+      "news": "Aktuelles",
+      "collection": "Sammlung",
+      "other": "Feldnotiz"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "Alle Orgeln",
+    "fieldNote": "Feldnotiz",
+    "previousVisit": "← Vorheriger Besuch",
+    "nextVisit": "Nächster Besuch →",
+    "endOfJournal": "— Ende des Journals —",
+    "minRead": "{count, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/en.json
+++ b/messages/en.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
+    "openMenu": "Abrir menú",
+    "closeMenu": "Cerrar menú",
     "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "taglineFallback": "Organista",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "Órganos",
+      "scores": "Partituras",
+      "about": "Sobre mí",
+      "elsewhere": "Otros sitios"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "privacy": "Privacidad",
+      "elsewhere": "Otros sitios",
+      "contact": "Contacto"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "home": "Inicio",
+    "organs": "Órganos",
+    "journal": "Diario",
+    "scores": "Partituras",
+    "about": "Sobre mí",
+    "elsewhere": "Otros sitios",
+    "privacy": "Privacidad"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "Idioma",
+    "switchTo": "Cambiar a {language}"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "Diario",
+      "description": "Ensayos, fragmentos, pensamientos a medio terminar — publicados cuando hay algo que valga la pena decir."
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "Órganos",
+      "description": "Notas de campo de órganos visitados en los Países Bajos y más allá."
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "Partituras",
+      "description": "Ediciones de trabajo de partituras para órgano preparadas por Bert Webbink — digitaciones, registraciones, de descarga gratuita para estudio no comercial."
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "Sobre mí",
+      "description": "Bert Webbink — organista, profesor, visitante silencioso de edificios antiguos."
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "Otros sitios",
+      "description": "Enlaces seleccionados — coros, iglesias, recursos para órgano."
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "Privacidad",
+      "description": "Una nota breve y en lenguaje sencillo sobre lo que se registra cuando visitas este sitio."
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "En construcción",
+    "subtitle": "Vuelve pronto."
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "Notas de campo",
+    "kickerRightFallback": "Desde la tribuna del órgano",
+    "headingFallback": "Visitas a {{órganos antiguos}}",
+    "taglineFallback": "Grabaciones, fotografías y registros de un sábado a la vez, recopilados en los Países Bajos y más allá.",
+    "cornerLeftSubFallback": "Un diario de campo",
+    "cornerRightSubFallback": "Los Países Bajos",
+    "stats": "Desde {firstYear} · {totalCount} órganos"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "Escritos",
+    "kickerRightFallback": "Un diario de campo",
+    "headingFallback": "El {{Diario}}",
+    "taglineFallback": "Ensayos, fragmentos, pensamientos a medio terminar — publicados cuando hay algo que valga la pena decir, generalmente después de que un banco me haya hecho cambiar de opinión sobre algo.",
+    "cornerLeftSubFallback": "Notas entre visitas",
+    "cornerRightSubFallback": "Los Países Bajos",
+    "stats": "Desde {firstYear} · {totalCount} entradas"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "El archivo",
+    "filteredTitle": "Visitas en <city>{city}</city>",
+    "byCity": "Por ciudad",
+    "browseAll": "Ver todos →",
+    "shownOfTotal": "{shown} de {total}",
+    "clearFilter": "quitar filtro ✕",
+    "loading": "Cargando…",
+    "endOfArchive": "— fin del archivo —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
-    "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "readMore": "Leer más",
+    "audioFragment": "Fragmento de audio",
+    "video": "Vídeo",
+    "placeholderLabel": "fotografía de órgano"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "Filtrar",
+    "all": "Todos",
     "categories": {
-      "travelogue": "Travel",
-      "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "travelogue": "Viajes",
+      "workshop": "Taller",
+      "memorial": "In memoriam",
+      "home-organ": "Órgano de casa",
+      "biography": "Biografía",
+      "news": "Noticias",
+      "collection": "Colección",
+      "other": "Otro"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "crónica de viaje",
+      "workshop": "visita",
+      "memorial": "in memoriam",
+      "home-organ": "órgano de casa",
+      "biography": "biografía",
+      "news": "noticia",
+      "collection": "colección",
+      "other": "nota"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count, plural, one {# entrada} other {# entradas}}",
+    "emptyCategory": "Aún no hay nada en esta categoría.",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← Más recientes",
+      "older": "Más antiguos →",
+      "pageOf": "Página {current} de {total}"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "Con audio",
+    "readEntry": "Leer entrada",
+    "minRead": "{count, plural, one {# min de lectura} other {# min de lectura}}"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "Disposición",
+    "manuals": "Manuales",
+    "stops": "Registros",
+    "pitch": "Tono",
+    "temperament": "Temperamento",
+    "action": "Acción",
+    "couplings": "Acoplamientos",
+    "accessories": "Accesorios",
+    "built": "Construido en {year}",
+    "restored": "Restaurado en {year}"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "Todos",
+      "baroque": "Barroco",
+      "dutch": "Escuela holandesa",
+      "romantic": "Romántico",
+      "modern": "Moderno",
+      "arrangement": "Arreglos"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "Compositor",
+      "year": "Año",
+      "edition": "Edición n.º"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
-    "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "headerKickerFallback": "Una pequeña biblioteca",
+    "headerHeadingFallback": "Ediciones, digitaciones, {{partituras de trabajo}}.",
+    "headerTaglineFallback": "Ediciones de trabajo que he preparado para mi propio uso, la mayoría para instrumentos específicos visitados en las notas de campo. Las digitaciones y registraciones son sugerencias, no prescripciones. Todas las partituras son de descarga gratuita para estudio no comercial.",
+    "noticeBodyFallback": "Estas partituras se comparten para estudio personal y uso en la iglesia. Si deseas interpretar o grabar una, se agradece un breve correo electrónico — y por favor, da crédito a la edición.",
+    "noticeEditionLineFallback": "Edición Webbink",
+    "writeToMe": "Escríbeme",
+    "emptyTitle": "La biblioteca se está configurando.",
+    "emptyBody": "Las ediciones aparecerán aquí a medida que las prepare. Vuelve a consultar o escríbeme a continuación.",
+    "editionsCount": "{count, plural, one {# edición} other {# ediciones}}",
+    "sort": "Ordenar: {label}",
+    "period": "Período",
+    "download": "Descargar",
+    "feature": "Edición destacada",
+    "featuredHeader": "Edición destacada",
+    "editionNumber": "N.º {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "Catálogo",
+      "period": "Período",
+      "pages": "Páginas",
+      "edition": "Edición"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "downloadPdf": "Descargar PDF",
+    "noPdfYet": "Aún no hay PDF",
     "editionLineSuffix": "· {year}",
     "pagesShort": "{count} pp",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "próximamente",
+    "libraryHeading": "La <em>biblioteca</em>",
+    "showing": "Mostrando {shown} de {total}",
+    "emptyFilter": "Aún no hay nada en esta categoría — prueba con otro filtro."
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "Sobre mí",
+    "emptyBody": "Esta página aún no se ha configurado en el Studio.",
+    "emptyHint": "Abre <code>/admin → Página Sobre mí</code> para añadir el contenido.",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "Trayectoria",
+    "trajectoryHeading": "Una breve <em>cronología</em> — cómo llegué hasta aquí.",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "Lo que toco",
+    "repertoireHeading": "Repertorio al que <em>siempre vuelvo</em>."
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "Privacidad",
+    "emptyBody": "Esta página aún no se ha configurado en el Studio.",
+    "emptyHint": "Abre <code>/admin → Página de privacidad</code> para añadir el contenido.",
+    "lastUpdated": "Última actualización: {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "Otros sitios",
+    "emptyTitle": "Otros sitios",
+    "emptyBody": "Esta página aún no se ha configurado en el Studio.",
+    "emptyHint": "Abre <code>/admin → Página de otros sitios</code> para añadir enlaces.",
+    "noLinks": "Aún no hay enlaces."
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "El diario",
+    "previousEntry": "← Entrada anterior",
+    "nextEntry": "Siguiente entrada →",
+    "endOfJournal": "— fin del diario —",
+    "minRead": "{count, plural, one {# min de lectura} other {# min de lectura}}",
     "categories": {
-      "travelogue": "Travelogue",
-      "workshop": "Workshop",
+      "travelogue": "Crónica de viaje",
+      "workshop": "Taller",
       "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "home-organ": "Órgano de casa",
+      "biography": "Biografía",
+      "news": "Noticias",
+      "collection": "Colección",
+      "other": "Nota de campo"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "Todos los órganos",
+    "fieldNote": "Nota de campo",
+    "previousVisit": "← Visita anterior",
+    "nextVisit": "Siguiente visita →",
+    "endOfJournal": "— fin del diario —",
+    "minRead": "{count, plural, one {# min de lectura} other {# min de lectura}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/es.json
+++ b/messages/es.json
@@ -43,7 +43,7 @@
     },
     "scores": {
       "title": "Partituras",
-      "description": "Ediciones de trabajo de partituras para órgano preparadas por Bert Webbink — digitaciones, registraciones, de descarga gratuita para estudio no comercial."
+      "description": "Ediciones de trabajo de partituras de órgano preparadas por Bert Webbink — digitaciones, registros, descarga gratuita para estudio no comercial."
     },
     "about": {
       "title": "Sobre mí",
@@ -51,11 +51,11 @@
     },
     "elsewhere": {
       "title": "Otros sitios",
-      "description": "Enlaces seleccionados — coros, iglesias, recursos para órgano."
+      "description": "Enlaces seleccionados — coros, iglesias, recursos de órgano."
     },
     "privacy": {
       "title": "Privacidad",
-      "description": "Una nota breve y en lenguaje sencillo sobre lo que se registra cuando visitas este sitio."
+      "description": "Una nota breve y sencilla sobre lo que se registra cuando visitas este sitio."
     }
   },
   "UnderConstruction": {
@@ -64,7 +64,7 @@
   },
   "Hero": {
     "kickerLeftFallback": "Notas de campo",
-    "kickerRightFallback": "Desde la tribuna del órgano",
+    "kickerRightFallback": "Desde el coro del órgano",
     "headingFallback": "Visitas a {{órganos antiguos}}",
     "taglineFallback": "Grabaciones, fotografías y registros de un sábado a la vez, recopilados en los Países Bajos y más allá.",
     "cornerLeftSubFallback": "Un diario de campo",
@@ -84,25 +84,25 @@
     "title": "El archivo",
     "filteredTitle": "Visitas en <city>{city}</city>",
     "byCity": "Por ciudad",
-    "browseAll": "Ver todos →",
+    "browseAll": "Ver todo →",
     "shownOfTotal": "{shown} de {total}",
-    "clearFilter": "quitar filtro ✕",
+    "clearFilter": "borrar filtro ✕",
     "loading": "Cargando…",
     "endOfArchive": "— fin del archivo —"
   },
   "OrganCard": {
     "readMore": "Leer más",
     "audioFragment": "Fragmento de audio",
-    "video": "Vídeo",
+    "video": "Video",
     "placeholderLabel": "fotografía de órgano"
   },
   "JournalList": {
     "filter": "Filtrar",
-    "all": "Todos",
+    "all": "Todo",
     "categories": {
       "travelogue": "Viajes",
       "workshop": "Taller",
-      "memorial": "In memoriam",
+      "memorial": "Memorial",
       "home-organ": "Órgano de casa",
       "biography": "Biografía",
       "news": "Noticias",
@@ -112,29 +112,29 @@
     "categoryKinds": {
       "travelogue": "crónica de viaje",
       "workshop": "visita",
-      "memorial": "in memoriam",
+      "memorial": "memorial",
       "home-organ": "órgano de casa",
       "biography": "biografía",
-      "news": "noticia",
+      "news": "noticias",
       "collection": "colección",
       "other": "nota"
     },
     "entriesCount": "{count, plural, one {# entrada} other {# entradas}}",
-    "emptyCategory": "Aún no hay nada en esta categoría.",
+    "emptyCategory": "Nada en esta categoría todavía.",
     "pagination": {
-      "newer": "← Más recientes",
-      "older": "Más antiguos →",
+      "newer": "← Más reciente",
+      "older": "Más antiguo →",
       "pageOf": "Página {current} de {total}"
     },
-    "hasAudio": "Con audio",
+    "hasAudio": "Tiene audio",
     "readEntry": "Leer entrada",
     "minRead": "{count, plural, one {# min de lectura} other {# min de lectura}}"
   },
   "Specs": {
-    "specification": "Disposición",
+    "specification": "Especificación",
     "manuals": "Manuales",
     "stops": "Registros",
-    "pitch": "Tono",
+    "pitch": "Afinación",
     "temperament": "Temperamento",
     "action": "Acción",
     "couplings": "Acoplamientos",
@@ -144,7 +144,7 @@
   },
   "Scores": {
     "filters": {
-      "all": "Todos",
+      "all": "Todo",
       "baroque": "Barroco",
       "dutch": "Escuela holandesa",
       "romantic": "Romántico",
@@ -154,12 +154,12 @@
     "sortBy": {
       "composer": "Compositor",
       "year": "Año",
-      "edition": "Edición n.º"
+      "edition": "Edición №"
     },
     "headerKickerFallback": "Una pequeña biblioteca",
     "headerHeadingFallback": "Ediciones, digitaciones, {{partituras de trabajo}}.",
-    "headerTaglineFallback": "Ediciones de trabajo que he preparado para mi propio uso, la mayoría para instrumentos específicos visitados en las notas de campo. Las digitaciones y registraciones son sugerencias, no prescripciones. Todas las partituras son de descarga gratuita para estudio no comercial.",
-    "noticeBodyFallback": "Estas partituras se comparten para estudio personal y uso en la iglesia. Si deseas interpretar o grabar una, se agradece un breve correo electrónico — y por favor, da crédito a la edición.",
+    "headerTaglineFallback": "Ediciones de trabajo que he preparado para mi propio uso — la mayoría para instrumentos específicos visitados en las notas de campo. Las digitaciones y registros son sugerencias, no prescripciones. Todas las partituras son de descarga gratuita para estudio no comercial.",
+    "noticeBodyFallback": "Estas partituras se comparten para estudio personal y uso eclesiástico. Si deseas interpretar o grabar una, se agradece un breve correo electrónico — y por favor, acredita la edición.",
     "noticeEditionLineFallback": "Edición Webbink",
     "writeToMe": "Escríbeme",
     "emptyTitle": "La biblioteca se está configurando.",
@@ -170,7 +170,7 @@
     "download": "Descargar",
     "feature": "Edición destacada",
     "featuredHeader": "Edición destacada",
-    "editionNumber": "N.º {number}",
+    "editionNumber": "Nº {number}",
     "meta": {
       "catalog": "Catálogo",
       "period": "Período",
@@ -180,35 +180,35 @@
     "downloadPdf": "Descargar PDF",
     "noPdfYet": "Aún no hay PDF",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "pagesShort": "{count} págs.",
     "pdfTag": "PDF",
-    "comingSoon": "próximamente",
+    "comingSoon": "pronto",
     "libraryHeading": "La <em>biblioteca</em>",
     "showing": "Mostrando {shown} de {total}",
-    "emptyFilter": "Aún no hay nada en esta categoría — prueba con otro filtro."
+    "emptyFilter": "Nada en esta categoría todavía — prueba otro filtro."
   },
   "About": {
     "emptyTitle": "Sobre mí",
-    "emptyBody": "Esta página aún no se ha configurado en el Studio.",
+    "emptyBody": "Esta página aún no se ha configurado en el Estudio.",
     "emptyHint": "Abre <code>/admin → Página Sobre mí</code> para añadir el contenido.",
     "trajectoryNum": "01",
     "trajectoryLabel": "Trayectoria",
-    "trajectoryHeading": "Una breve <em>cronología</em> — cómo llegué hasta aquí.",
+    "trajectoryHeading": "Una breve <em>cronología</em> — cómo llegué aquí.",
     "repertoireNum": "02",
     "repertoireLabel": "Lo que toco",
     "repertoireHeading": "Repertorio al que <em>siempre vuelvo</em>."
   },
   "Privacy": {
     "emptyTitle": "Privacidad",
-    "emptyBody": "Esta página aún no se ha configurado en el Studio.",
+    "emptyBody": "Esta página aún no se ha configurado en el Estudio.",
     "emptyHint": "Abre <code>/admin → Página de privacidad</code> para añadir el contenido.",
     "lastUpdated": "Última actualización: {date}"
   },
   "Elsewhere": {
     "title": "Otros sitios",
     "emptyTitle": "Otros sitios",
-    "emptyBody": "Esta página aún no se ha configurado en el Studio.",
-    "emptyHint": "Abre <code>/admin → Página de otros sitios</code> para añadir enlaces.",
+    "emptyBody": "Esta página aún no se ha configurado en el Estudio.",
+    "emptyHint": "Abre <code>/admin → Página Otros sitios</code> para añadir enlaces.",
     "noLinks": "Aún no hay enlaces."
   },
   "JournalArticle": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -30,7 +30,7 @@
   },
   "LanguagePicker": {
     "label": "Langue",
-    "switchTo": "Passer en {language}"
+    "switchTo": "Passer au {language}"
   },
   "Metadata": {
     "journal": {
@@ -43,19 +43,19 @@
     },
     "scores": {
       "title": "Partitions",
-      "description": "Éditions de travail de partitions d'orgue préparées par Bert Webbink — doigtés, registrations, à télécharger gratuitement pour étude non commerciale."
+      "description": "Éditions de travail de partitions d'orgue préparées par Bert Webbink — doigtés, registrations, téléchargeables gratuitement pour étude non commerciale."
     },
     "about": {
       "title": "À propos",
-      "description": "Bert Webbink — organiste, professeur, visiteur silencieux de vieilles bâtisses."
+      "description": "Bert Webbink — organiste, professeur, visiteur discret de vieux bâtiments."
     },
     "elsewhere": {
       "title": "Ailleurs",
-      "description": "Sélection de liens — chœurs, églises, ressources sur l'orgue."
+      "description": "Liens sélectionnés — chœurs, églises, ressources sur l'orgue."
     },
     "privacy": {
       "title": "Confidentialité",
-      "description": "Une note brève et simple sur ce qui est enregistré lorsque vous visitez ce site."
+      "description": "Une note courte et simple sur ce qui est enregistré lorsque vous visitez ce site."
     }
   },
   "UnderConstruction": {
@@ -64,31 +64,31 @@
   },
   "Hero": {
     "kickerLeftFallback": "Notes de terrain",
-    "kickerRightFallback": "Depuis la tribune",
-    "headingFallback": "Visites d'{{orgues anciens}}",
-    "taglineFallback": "Enregistrements, photographies et jeux d'orgues, un samedi à la fois, recueillis aux Pays-Bas et au-delà.",
+    "kickerRightFallback": "Depuis la tribune d'orgue",
+    "headingFallback": "Visites d' {{orgues anciens}}",
+    "taglineFallback": "Enregistrements, photographies et registres d'un samedi à la fois, recueillis aux Pays-Bas et au-delà.",
     "cornerLeftSubFallback": "Un journal de terrain",
-    "cornerRightSubFallback": "Les plats pays",
+    "cornerRightSubFallback": "Les Pays-Bas",
     "stats": "Depuis {firstYear} · {totalCount} orgues"
   },
   "JournalHero": {
     "kickerLeftFallback": "Écrits",
     "kickerRightFallback": "Un journal de terrain",
     "headingFallback": "Le {{Journal}}",
-    "taglineFallback": "Essais, fragments, pensées inachevées — publiés quand il y a quelque chose à dire, généralement après qu'un banc m'ait fait changer d'avis.",
+    "taglineFallback": "Essais, fragments, pensées inachevées — publiés quand il y a quelque chose à dire, généralement après qu'un banc m'ait fait changer d'avis sur quelque chose.",
     "cornerLeftSubFallback": "Notes entre les visites",
-    "cornerRightSubFallback": "Les plats pays",
-    "stats": "Depuis {firstYear} · {totalCount} articles"
+    "cornerRightSubFallback": "Les Pays-Bas",
+    "stats": "Depuis {firstYear} · {totalCount} entrées"
   },
   "OrgansArchive": {
-    "title": "Les archives",
+    "title": "L'archive",
     "filteredTitle": "Visites à <city>{city}</city>",
     "byCity": "Par ville",
     "browseAll": "Tout parcourir →",
     "shownOfTotal": "{shown} sur {total}",
     "clearFilter": "effacer le filtre ✕",
     "loading": "Chargement…",
-    "endOfArchive": "— fin des archives —"
+    "endOfArchive": "— fin de l'archive —"
   },
   "OrganCard": {
     "readMore": "Lire la suite",
@@ -98,45 +98,45 @@
   },
   "JournalList": {
     "filter": "Filtrer",
-    "all": "Tous",
+    "all": "Tout",
     "categories": {
       "travelogue": "Voyage",
       "workshop": "Atelier",
       "memorial": "Mémorial",
-      "home-organ": "Orgue de salon",
+      "home-organ": "Orgue de maison",
       "biography": "Biographie",
       "news": "Actualités",
       "collection": "Collection",
       "other": "Autre"
     },
     "categoryKinds": {
-      "travelogue": "récit de voyage",
+      "travelogue": "carnet de voyage",
       "workshop": "visite",
       "memorial": "mémorial",
-      "home-organ": "orgue de salon",
+      "home-organ": "orgue de maison",
       "biography": "biographie",
       "news": "actualité",
       "collection": "collection",
       "other": "note"
     },
-    "entriesCount": "{count, plural, one {# article} other {# articles}}",
-    "emptyCategory": "Rien dans cette catégorie pour le moment.",
+    "entriesCount": "{count, plural, one {# entrée} other {# entrées}}",
+    "emptyCategory": "Rien dans cette catégorie pour l'instant.",
     "pagination": {
-      "newer": "← Plus récents",
-      "older": "Plus anciens →",
+      "newer": "← Plus récent",
+      "older": "Plus ancien →",
       "pageOf": "Page {current} sur {total}"
     },
     "hasAudio": "Avec audio",
-    "readEntry": "Lire l'article",
+    "readEntry": "Lire l'entrée",
     "minRead": "{count, plural, one {# min de lecture} other {# min de lecture}}"
   },
   "Specs": {
-    "specification": "Composition",
-    "manuals": "Claviers",
-    "stops": "Jeux",
+    "specification": "Spécification",
+    "manuals": "Manuels",
+    "stops": "Registres",
     "pitch": "Diapason",
     "temperament": "Tempérament",
-    "action": "Traction",
+    "action": "Action",
     "couplings": "Accouplements",
     "accessories": "Accessoires",
     "built": "Construit en {year}",
@@ -144,7 +144,7 @@
   },
   "Scores": {
     "filters": {
-      "all": "Tous",
+      "all": "Tout",
       "baroque": "Baroque",
       "dutch": "École hollandaise",
       "romantic": "Romantique",
@@ -154,15 +154,15 @@
     "sortBy": {
       "composer": "Compositeur",
       "year": "Année",
-      "edition": "Édition n°"
+      "edition": "Édition №"
     },
     "headerKickerFallback": "Une petite bibliothèque",
     "headerHeadingFallback": "Éditions, doigtés, {{partitions de travail}}.",
-    "headerTaglineFallback": "Éditions de travail que j'ai préparées pour mon propre usage — la plupart pour des instruments spécifiques visités dans les notes de terrain. Les doigtés et les registrations sont des suggestions, pas des prescriptions. Toutes les partitions sont à télécharger gratuitement pour une étude non commerciale.",
-    "noticeBodyFallback": "Ces partitions sont partagées pour l'étude personnelle et l'usage liturgique. Si vous souhaitez en jouer ou en enregistrer une, un court e-mail est apprécié — et veuillez créditer l'édition.",
+    "headerTaglineFallback": "Éditions de travail que j'ai préparées pour mon usage personnel — la plupart pour des instruments spécifiques visités dans les notes de terrain. Les doigtés et les registrations sont des suggestions, pas des prescriptions. Toutes les partitions sont téléchargeables gratuitement pour étude non commerciale.",
+    "noticeBodyFallback": "Ces partitions sont partagées pour l'étude personnelle et l'utilisation en église. Si vous souhaitez en interpréter ou en enregistrer une, un court e-mail est apprécié — et veuillez créditer l'édition.",
     "noticeEditionLineFallback": "Édition Webbink",
     "writeToMe": "Écrivez-moi",
-    "emptyTitle": "La bibliothèque est en cours de création.",
+    "emptyTitle": "La bibliothèque est en cours de mise en place.",
     "emptyBody": "Les éditions apparaîtront ici au fur et à mesure que je les préparerai. Revenez plus tard, ou écrivez-moi ci-dessous.",
     "editionsCount": "{count, plural, one {# édition} other {# éditions}}",
     "sort": "Trier : {label}",
@@ -184,44 +184,44 @@
     "pdfTag": "PDF",
     "comingSoon": "bientôt",
     "libraryHeading": "La <em>bibliothèque</em>",
-    "showing": "{shown} sur {total}",
-    "emptyFilter": "Rien dans cette catégorie pour le moment — essayez un autre filtre."
+    "showing": "Affichage de {shown} sur {total}",
+    "emptyFilter": "Rien dans cette catégorie pour l'instant — essayez un autre filtre."
   },
   "About": {
     "emptyTitle": "À propos",
     "emptyBody": "Cette page n'a pas encore été configurée dans le Studio.",
-    "emptyHint": "Ouvrez <code>/admin → Page À propos</code> pour ajouter le contenu.",
+    "emptyHint": "Ouvrez <code>/admin → About page</code> pour ajouter le contenu.",
     "trajectoryNum": "01",
     "trajectoryLabel": "Parcours",
-    "trajectoryHeading": "Une brève <em>chronologie</em> — comment j'en suis arrivé là.",
+    "trajectoryHeading": "Une courte <em>chronologie</em> — comment j'en suis arrivé là.",
     "repertoireNum": "02",
     "repertoireLabel": "Ce que je joue",
-    "repertoireHeading": "Le répertoire auquel je <em>reviens</em> sans cesse."
+    "repertoireHeading": "Répertoire auquel je <em>reviens</em> toujours."
   },
   "Privacy": {
     "emptyTitle": "Confidentialité",
     "emptyBody": "Cette page n'a pas encore été configurée dans le Studio.",
-    "emptyHint": "Ouvrez <code>/admin → Page Confidentialité</code> pour ajouter le contenu.",
+    "emptyHint": "Ouvrez <code>/admin → Privacy page</code> pour ajouter le contenu.",
     "lastUpdated": "Dernière mise à jour le {date}"
   },
   "Elsewhere": {
     "title": "Ailleurs",
     "emptyTitle": "Ailleurs",
     "emptyBody": "Cette page n'a pas encore été configurée dans le Studio.",
-    "emptyHint": "Ouvrez <code>/admin → Page Ailleurs</code> pour ajouter des liens.",
+    "emptyHint": "Ouvrez <code>/admin → Elsewhere page</code> pour ajouter des liens.",
     "noLinks": "Pas encore de liens."
   },
   "JournalArticle": {
     "breadcrumbHome": "Le journal",
-    "previousEntry": "← Article précédent",
-    "nextEntry": "Article suivant →",
+    "previousEntry": "← Entrée précédente",
+    "nextEntry": "Entrée suivante →",
     "endOfJournal": "— fin du journal —",
     "minRead": "{count, plural, one {# min de lecture} other {# min de lecture}}",
     "categories": {
-      "travelogue": "Récit de voyage",
+      "travelogue": "Carnet de voyage",
       "workshop": "Atelier",
       "memorial": "In memoriam",
-      "home-organ": "Orgue de salon",
+      "home-organ": "Orgue de maison",
       "biography": "Biographie",
       "news": "Actualités",
       "collection": "Collection",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
+    "openMenu": "Ouvrir le menu",
+    "closeMenu": "Fermer le menu",
     "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "taglineFallback": "Organiste",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "Orgues",
+      "scores": "Partitions",
+      "about": "À propos",
+      "elsewhere": "Ailleurs"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
+      "privacy": "Confidentialité",
+      "elsewhere": "Ailleurs",
       "contact": "Contact"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
+    "home": "Accueil",
+    "organs": "Orgues",
     "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "scores": "Partitions",
+    "about": "À propos",
+    "elsewhere": "Ailleurs",
+    "privacy": "Confidentialité"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "Langue",
+    "switchTo": "Passer en {language}"
   },
   "Metadata": {
     "journal": {
       "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "description": "Essais, fragments, pensées inachevées — publiés quand il y a quelque chose à dire."
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "Orgues",
+      "description": "Notes de terrain sur les orgues visités aux Pays-Bas et au-delà."
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "Partitions",
+      "description": "Éditions de travail de partitions d'orgue préparées par Bert Webbink — doigtés, registrations, à télécharger gratuitement pour étude non commerciale."
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "À propos",
+      "description": "Bert Webbink — organiste, professeur, visiteur silencieux de vieilles bâtisses."
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "Ailleurs",
+      "description": "Sélection de liens — chœurs, églises, ressources sur l'orgue."
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "Confidentialité",
+      "description": "Une note brève et simple sur ce qui est enregistré lorsque vous visitez ce site."
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "En construction",
+    "subtitle": "Revenez bientôt."
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "Notes de terrain",
+    "kickerRightFallback": "Depuis la tribune",
+    "headingFallback": "Visites d'{{orgues anciens}}",
+    "taglineFallback": "Enregistrements, photographies et jeux d'orgues, un samedi à la fois, recueillis aux Pays-Bas et au-delà.",
+    "cornerLeftSubFallback": "Un journal de terrain",
+    "cornerRightSubFallback": "Les plats pays",
+    "stats": "Depuis {firstYear} · {totalCount} orgues"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "Écrits",
+    "kickerRightFallback": "Un journal de terrain",
+    "headingFallback": "Le {{Journal}}",
+    "taglineFallback": "Essais, fragments, pensées inachevées — publiés quand il y a quelque chose à dire, généralement après qu'un banc m'ait fait changer d'avis.",
+    "cornerLeftSubFallback": "Notes entre les visites",
+    "cornerRightSubFallback": "Les plats pays",
+    "stats": "Depuis {firstYear} · {totalCount} articles"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "Les archives",
+    "filteredTitle": "Visites à <city>{city}</city>",
+    "byCity": "Par ville",
+    "browseAll": "Tout parcourir →",
+    "shownOfTotal": "{shown} sur {total}",
+    "clearFilter": "effacer le filtre ✕",
+    "loading": "Chargement…",
+    "endOfArchive": "— fin des archives —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
-    "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "readMore": "Lire la suite",
+    "audioFragment": "Extrait audio",
+    "video": "Vidéo",
+    "placeholderLabel": "photographie d'orgue"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "Filtrer",
+    "all": "Tous",
     "categories": {
-      "travelogue": "Travel",
-      "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
+      "travelogue": "Voyage",
+      "workshop": "Atelier",
+      "memorial": "Mémorial",
+      "home-organ": "Orgue de salon",
+      "biography": "Biographie",
+      "news": "Actualités",
       "collection": "Collection",
-      "other": "Other"
+      "other": "Autre"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
+      "travelogue": "récit de voyage",
+      "workshop": "visite",
+      "memorial": "mémorial",
+      "home-organ": "orgue de salon",
+      "biography": "biographie",
+      "news": "actualité",
       "collection": "collection",
       "other": "note"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count, plural, one {# article} other {# articles}}",
+    "emptyCategory": "Rien dans cette catégorie pour le moment.",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← Plus récents",
+      "older": "Plus anciens →",
+      "pageOf": "Page {current} sur {total}"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "Avec audio",
+    "readEntry": "Lire l'article",
+    "minRead": "{count, plural, one {# min de lecture} other {# min de lecture}}"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "Composition",
+    "manuals": "Claviers",
+    "stops": "Jeux",
+    "pitch": "Diapason",
+    "temperament": "Tempérament",
+    "action": "Traction",
+    "couplings": "Accouplements",
+    "accessories": "Accessoires",
+    "built": "Construit en {year}",
+    "restored": "Restauré en {year}"
   },
   "Scores": {
     "filters": {
-      "all": "All",
+      "all": "Tous",
       "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
+      "dutch": "École hollandaise",
+      "romantic": "Romantique",
+      "modern": "Moderne",
       "arrangement": "Arrangements"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "Compositeur",
+      "year": "Année",
+      "edition": "Édition n°"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
-    "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "headerKickerFallback": "Une petite bibliothèque",
+    "headerHeadingFallback": "Éditions, doigtés, {{partitions de travail}}.",
+    "headerTaglineFallback": "Éditions de travail que j'ai préparées pour mon propre usage — la plupart pour des instruments spécifiques visités dans les notes de terrain. Les doigtés et les registrations sont des suggestions, pas des prescriptions. Toutes les partitions sont à télécharger gratuitement pour une étude non commerciale.",
+    "noticeBodyFallback": "Ces partitions sont partagées pour l'étude personnelle et l'usage liturgique. Si vous souhaitez en jouer ou en enregistrer une, un court e-mail est apprécié — et veuillez créditer l'édition.",
+    "noticeEditionLineFallback": "Édition Webbink",
+    "writeToMe": "Écrivez-moi",
+    "emptyTitle": "La bibliothèque est en cours de création.",
+    "emptyBody": "Les éditions apparaîtront ici au fur et à mesure que je les préparerai. Revenez plus tard, ou écrivez-moi ci-dessous.",
+    "editionsCount": "{count, plural, one {# édition} other {# éditions}}",
+    "sort": "Trier : {label}",
+    "period": "Période",
+    "download": "Télécharger",
+    "feature": "Édition en vedette",
+    "featuredHeader": "Édition en vedette",
+    "editionNumber": "N° {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
+      "catalog": "Catalogue",
+      "period": "Période",
       "pages": "Pages",
-      "edition": "Edition"
+      "edition": "Édition"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "downloadPdf": "Télécharger le PDF",
+    "noPdfYet": "Pas encore de PDF",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "pagesShort": "{count} p.",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "bientôt",
+    "libraryHeading": "La <em>bibliothèque</em>",
+    "showing": "{shown} sur {total}",
+    "emptyFilter": "Rien dans cette catégorie pour le moment — essayez un autre filtre."
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "À propos",
+    "emptyBody": "Cette page n'a pas encore été configurée dans le Studio.",
+    "emptyHint": "Ouvrez <code>/admin → Page À propos</code> pour ajouter le contenu.",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "Parcours",
+    "trajectoryHeading": "Une brève <em>chronologie</em> — comment j'en suis arrivé là.",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "Ce que je joue",
+    "repertoireHeading": "Le répertoire auquel je <em>reviens</em> sans cesse."
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "Confidentialité",
+    "emptyBody": "Cette page n'a pas encore été configurée dans le Studio.",
+    "emptyHint": "Ouvrez <code>/admin → Page Confidentialité</code> pour ajouter le contenu.",
+    "lastUpdated": "Dernière mise à jour le {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "Ailleurs",
+    "emptyTitle": "Ailleurs",
+    "emptyBody": "Cette page n'a pas encore été configurée dans le Studio.",
+    "emptyHint": "Ouvrez <code>/admin → Page Ailleurs</code> pour ajouter des liens.",
+    "noLinks": "Pas encore de liens."
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "Le journal",
+    "previousEntry": "← Article précédent",
+    "nextEntry": "Article suivant →",
+    "endOfJournal": "— fin du journal —",
+    "minRead": "{count, plural, one {# min de lecture} other {# min de lecture}}",
     "categories": {
-      "travelogue": "Travelogue",
-      "workshop": "Workshop",
+      "travelogue": "Récit de voyage",
+      "workshop": "Atelier",
       "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
+      "home-organ": "Orgue de salon",
+      "biography": "Biographie",
+      "news": "Actualités",
       "collection": "Collection",
-      "other": "Field note"
+      "other": "Note de terrain"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "Tous les orgues",
+    "fieldNote": "Note de terrain",
+    "previousVisit": "← Visite précédente",
+    "nextVisit": "Visite suivante →",
+    "endOfJournal": "— fin du journal —",
+    "minRead": "{count, plural, one {# min de lecture} other {# min de lecture}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,9 +1,9 @@
 {
   "Nav": {
-    "openMenu": "मेन्यू खोलें",
-    "closeMenu": "मेन्यू बंद करें",
+    "openMenu": "मेनू खोलें",
+    "closeMenu": "मेनू बंद करें",
     "wordmarkFallback": "बर्ट वेबिंक",
-    "taglineFallback": "ऑर्गनिस्ट",
+    "taglineFallback": "ऑर्गेनिस्ट",
     "items": {
       "organs": "ऑर्गन",
       "scores": "स्कोर",
@@ -14,9 +14,9 @@
   "Footer": {
     "copyright": "© बर्ट वेबिंक, {year}",
     "links": {
-      "privacy": "निजता",
+      "privacy": "गोपनीयता",
       "elsewhere": "अन्यत्र",
-      "contact": "संपर्क"
+      "contact": "संपर्क करें"
     }
   },
   "Crumbs": {
@@ -24,9 +24,9 @@
     "organs": "ऑर्गन",
     "journal": "जर्नल",
     "scores": "स्कोर",
-    "about": "परिचय",
+    "about": "के बारे में",
     "elsewhere": "अन्यत्र",
-    "privacy": "निजता"
+    "privacy": "गोपनीयता"
   },
   "LanguagePicker": {
     "label": "भाषा",
@@ -35,49 +35,49 @@
   "Metadata": {
     "journal": {
       "title": "जर्नल",
-      "description": "निबंध, अंश, अधूरे विचार — तब प्रकाशित होते हैं जब कुछ कहने लायक होता है।"
+      "description": "निबंध, अंश, अधूरे विचार — तभी प्रकाशित होते हैं जब कहने लायक कुछ होता है।"
     },
     "organs": {
       "title": "ऑर्गन",
-      "description": "नीदरलैंड और उसके बाहर देखे गए ऑर्गन से फ़ील्ड नोट्स।"
+      "description": "नीदरलैंड और उससे आगे के ऑर्गन से फील्ड नोट्स।"
     },
     "scores": {
       "title": "स्कोर",
-      "description": "बर्ट वेबिंक द्वारा तैयार किए गए ऑर्गन स्कोर के वर्किंग एडिशन — फिंगरिंग, रजिस्ट्रेशन, गैर-व्यावसायिक अध्ययन के लिए मुफ्त डाउनलोड।"
+      "description": "बर्ट वेबिंक द्वारा तैयार किए गए ऑर्गन स्कोर के कार्य संस्करण — फिंगरिंग, पंजीकरण, गैर-व्यावसायिक अध्ययन के लिए मुफ्त डाउनलोड।"
     },
     "about": {
       "title": "मेरे बारे में",
-      "description": "बर्ट वेबिंक — ऑर्गनिस्ट, शिक्षक, पुरानी इमारतों का शांत आगंतुक।"
+      "description": "बर्ट वेबिंक — ऑर्गेनिस्ट, शिक्षक, पुरानी इमारतों के शांत आगंतुक।"
     },
     "elsewhere": {
       "title": "अन्यत्र",
-      "description": "चुने हुए लिंक — गायक मंडल, चर्च, ऑर्गन संसाधन।"
+      "description": "क्यूरेटेड लिंक — गायक-मंडलियां, चर्च, ऑर्गन संसाधन।"
     },
     "privacy": {
-      "title": "निजता",
-      "description": "इस साइट पर आने पर क्या लॉग किया जाता है, इसके बारे में एक संक्षिप्त, सरल भाषा में नोट।"
+      "title": "गोपनीयता",
+      "description": "इस साइट पर आने पर क्या लॉग किया जाता है, इसके बारे में एक छोटा, सरल-भाषा नोट।"
     }
   },
   "UnderConstruction": {
     "title": "निर्माणाधीन",
-    "subtitle": "जल्द ही वापस आएँ।"
+    "subtitle": "जल्द ही वापस आएं।"
   },
   "Hero": {
-    "kickerLeftFallback": "फ़ील्ड नोट्स",
-    "kickerRightFallback": "ऑर्गन लॉफ़्ट से",
-    "headingFallback": "{{पुराने ऑर्गन}} की यात्राएँ",
-    "taglineFallback": "नीदरलैंड और उसके बाहर से हर शनिवार को इकट्ठा की गई रिकॉर्डिंग, तस्वीरें और रजिस्टर।",
-    "cornerLeftSubFallback": "एक फ़ील्ड जर्नल",
-    "cornerRightSubFallback": "निम्न देश",
+    "kickerLeftFallback": "फील्ड नोट्स",
+    "kickerRightFallback": "ऑर्गन लॉफ्ट से",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "नीदरलैंड और उससे आगे से एक-एक शनिवार के रिकॉर्डिंग, तस्वीरें और रजिस्टर।",
+    "cornerLeftSubFallback": "एक फील्ड जर्नल",
+    "cornerRightSubFallback": "निचले देश",
     "stats": "{firstYear} से · {totalCount} ऑर्गन"
   },
   "JournalHero": {
     "kickerLeftFallback": "लेखन",
-    "kickerRightFallback": "एक फ़ील्ड जर्नल",
-    "headingFallback": "{{जर्नल}}",
-    "taglineFallback": "निबंध, अंश, अधूरे विचार — जब कुछ कहने लायक होता है तब प्रकाशित होते हैं, आमतौर पर जब किसी बेंच ने मेरा मन बदल दिया हो।",
-    "cornerLeftSubFallback": "यात्राओं के बीच के नोट्स",
-    "cornerRightSubFallback": "निम्न देश",
+    "kickerRightFallback": "एक फील्ड जर्नल",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "निबंध, अंश, अधूरे विचार — तभी प्रकाशित होते हैं जब कहने लायक कुछ होता है, आमतौर पर जब किसी बेंच ने किसी चीज़ के बारे में मेरा विचार बदल दिया हो।",
+    "cornerLeftSubFallback": "यात्राओं के बीच नोट्स",
+    "cornerRightSubFallback": "निचले देश",
     "stats": "{firstYear} से · {totalCount} प्रविष्टियाँ"
   },
   "OrgansArchive": {
@@ -103,7 +103,7 @@
       "travelogue": "यात्रा",
       "workshop": "कार्यशाला",
       "memorial": "स्मृति",
-      "home-organ": "घरेलू ऑर्गन",
+      "home-organ": "होम ऑर्गन",
       "biography": "जीवनी",
       "news": "समाचार",
       "collection": "संग्रह",
@@ -113,7 +113,7 @@
       "travelogue": "यात्रा वृत्तांत",
       "workshop": "यात्रा",
       "memorial": "स्मृति",
-      "home-organ": "घरेलू ऑर्गन",
+      "home-organ": "होम ऑर्गन",
       "biography": "जीवनी",
       "news": "समाचार",
       "collection": "संग्रह",
@@ -122,30 +122,30 @@
     "entriesCount": "{count, plural, one {# प्रविष्टि} other {# प्रविष्टियाँ}}",
     "emptyCategory": "इस श्रेणी में अभी कुछ भी नहीं है।",
     "pagination": {
-      "newer": "← नए",
-      "older": "पुराने →",
-      "pageOf": "पेज {current} / {total}"
+      "newer": "← नया",
+      "older": "पुराना →",
+      "pageOf": "पृष्ठ {total} में से {current}"
     },
     "hasAudio": "ऑडियो है",
     "readEntry": "प्रविष्टि पढ़ें",
-    "minRead": "{count, plural, one {# मिनट का पठन} other {# मिनट का पठन}}"
+    "minRead": "{count, plural, one {# मिनट पढ़ें} other {# मिनट पढ़ें}}"
   },
   "Specs": {
     "specification": "विनिर्देश",
     "manuals": "मैनुअल",
     "stops": "स्टॉप",
     "pitch": "पिच",
-    "temperament": "टेम्परामेंट",
-    "action": "एक्शन",
-    "couplings": "कपलिंग",
-    "accessories": "एक्सेसरीज़",
+    "temperament": "स्वभाव",
+    "action": "क्रिया",
+    "couplings": "युग्मन",
+    "accessories": "सहायक उपकरण",
     "built": "{year} में निर्मित",
-    "restored": "{year} में पुनर्स्थापित"
+    "restored": "{year} में बहाल"
   },
   "Scores": {
     "filters": {
       "all": "सभी",
-      "baroque": "बैरोक",
+      "baroque": "बरोक",
       "dutch": "डच स्कूल",
       "romantic": "रोमांटिक",
       "modern": "आधुनिक",
@@ -154,87 +154,87 @@
     "sortBy": {
       "composer": "संगीतकार",
       "year": "वर्ष",
-      "edition": "संस्करण №"
+      "edition": "संस्करण संख्या"
     },
     "headerKickerFallback": "एक छोटी लाइब्रेरी",
-    "headerHeadingFallback": "संस्करण, फिंगरिंग, {{वर्किंग स्कोर}}।",
-    "headerTaglineFallback": "मेरे अपने उपयोग के लिए तैयार किए गए वर्किंग एडिशन — ज़्यादातर फ़ील्ड नोट्स में देखे गए विशिष्ट उपकरणों के लिए। फिंगरिंग और रजिस्ट्रेशन सुझाव हैं, निर्देश नहीं। सभी स्कोर गैर-व्यावसायिक अध्ययन के लिए मुफ्त डाउनलोड किए जा सकते हैं।",
-    "noticeBodyFallback": "ये स्कोर व्यक्तिगत अध्ययन और चर्च के उपयोग के लिए साझा किए गए हैं। यदि आप किसी एक का प्रदर्शन या रिकॉर्ड करना चाहते हैं, तो एक संक्षिप्त ईमेल की सराहना की जाएगी — और कृपया संस्करण को श्रेय दें।",
+    "headerHeadingFallback": "संस्करण, फिंगरिंग, {{कार्य स्कोर}}।",
+    "headerTaglineFallback": "मेरे अपने उपयोग के लिए तैयार किए गए कार्य संस्करण — अधिकांश फील्ड नोट्स में देखे गए विशिष्ट उपकरणों के लिए। फिंगरिंग और पंजीकरण सुझाव हैं, नुस्खे नहीं। सभी स्कोर गैर-व्यावसायिक अध्ययन के लिए मुफ्त डाउनलोड के लिए उपलब्ध हैं।",
+    "noticeBodyFallback": "ये स्कोर व्यक्तिगत अध्ययन और चर्च के उपयोग के लिए साझा किए जाते हैं। यदि आप किसी एक को प्रस्तुत या रिकॉर्ड करना चाहते हैं, तो एक छोटा ईमेल सराहनीय है — और कृपया संस्करण को श्रेय दें।",
     "noticeEditionLineFallback": "संस्करण वेबिंक",
     "writeToMe": "मुझे लिखें",
     "emptyTitle": "लाइब्रेरी अभी स्थापित की जा रही है।",
-    "emptyBody": "जैसे ही मैं उन्हें तैयार करूँगा, संस्करण यहाँ दिखाई देंगे। वापस जाँचें, या नीचे मुझे लिखें।",
+    "emptyBody": "जैसे ही मैं उन्हें तैयार करूँगा, संस्करण यहाँ दिखाई देंगे। वापस जाँच करें, या मुझे नीचे लिखें।",
     "editionsCount": "{count, plural, one {# संस्करण} other {# संस्करण}}",
     "sort": "क्रमबद्ध करें: {label}",
     "period": "अवधि",
     "download": "डाउनलोड करें",
     "feature": "विशेष संस्करण",
     "featuredHeader": "विशेष संस्करण",
-    "editionNumber": "नं. {number}",
+    "editionNumber": "सं. {number}",
     "meta": {
       "catalog": "कैटलॉग",
       "period": "अवधि",
-      "pages": "पेज",
+      "pages": "पृष्ठ",
       "edition": "संस्करण"
     },
-    "downloadPdf": "PDF डाउनलोड करें",
-    "noPdfYet": "अभी तक कोई PDF नहीं",
+    "downloadPdf": "पीडीएफ डाउनलोड करें",
+    "noPdfYet": "अभी कोई पीडीएफ नहीं",
     "editionLineSuffix": "· {year}",
     "pagesShort": "{count} पृष्ठ",
-    "pdfTag": "PDF",
+    "pdfTag": "पीडीएफ",
     "comingSoon": "जल्द ही",
     "libraryHeading": "<em>लाइब्रेरी</em>",
     "showing": "{total} में से {shown} दिखा रहा है",
-    "emptyFilter": "इस श्रेणी में अभी कुछ भी नहीं है — दूसरा फ़िल्टर आज़माएँ।"
+    "emptyFilter": "इस श्रेणी में अभी कुछ भी नहीं है — कोई अन्य फ़िल्टर आज़माएँ।"
   },
   "About": {
     "emptyTitle": "मेरे बारे में",
-    "emptyBody": "यह पेज अभी तक स्टूडियो में सेट नहीं किया गया है।",
+    "emptyBody": "यह पृष्ठ अभी तक स्टूडियो में सेट नहीं किया गया है।",
     "emptyHint": "सामग्री जोड़ने के लिए <code>/admin → About page</code> खोलें।",
     "trajectoryNum": "01",
-    "trajectoryLabel": "यात्रा",
+    "trajectoryLabel": "प्रक्षेपवक्र",
     "trajectoryHeading": "एक संक्षिप्त <em>कालक्रम</em> — मैं यहाँ कैसे पहुँचा।",
     "repertoireNum": "02",
     "repertoireLabel": "मैं क्या बजाता हूँ",
-    "repertoireHeading": "रेपर्टरी जिस पर मैं <em>वापस आता रहता हूँ</em>।"
+    "repertoireHeading": "संग्रह जिसमें मैं <em>वापस आता रहता हूँ</em>।"
   },
   "Privacy": {
-    "emptyTitle": "निजता",
-    "emptyBody": "यह पेज अभी तक स्टूडियो में सेट नहीं किया गया है।",
+    "emptyTitle": "गोपनीयता",
+    "emptyBody": "यह पृष्ठ अभी तक स्टूडियो में सेट नहीं किया गया है।",
     "emptyHint": "सामग्री जोड़ने के लिए <code>/admin → Privacy page</code> खोलें।",
     "lastUpdated": "अंतिम अपडेट {date}"
   },
   "Elsewhere": {
     "title": "अन्यत्र",
     "emptyTitle": "अन्यत्र",
-    "emptyBody": "यह पेज अभी तक स्टूडियो में सेट नहीं किया गया है।",
+    "emptyBody": "यह पृष्ठ अभी तक स्टूडियो में सेट नहीं किया गया है।",
     "emptyHint": "लिंक जोड़ने के लिए <code>/admin → Elsewhere page</code> खोलें।",
-    "noLinks": "अभी तक कोई लिंक नहीं।"
+    "noLinks": "अभी कोई लिंक नहीं।"
   },
   "JournalArticle": {
     "breadcrumbHome": "जर्नल",
     "previousEntry": "← पिछली प्रविष्टि",
     "nextEntry": "अगली प्रविष्टि →",
     "endOfJournal": "— जर्नल का अंत —",
-    "minRead": "{count, plural, one {# मिनट का पठन} other {# मिनट का पठन}}",
+    "minRead": "{count, plural, one {# मिनट पढ़ें} other {# मिनट पढ़ें}}",
     "categories": {
       "travelogue": "यात्रा वृत्तांत",
       "workshop": "कार्यशाला",
       "memorial": "स्मृति में",
-      "home-organ": "घरेलू ऑर्गन",
+      "home-organ": "होम ऑर्गन",
       "biography": "जीवनी",
       "news": "समाचार",
       "collection": "संग्रह",
-      "other": "फ़ील्ड नोट"
+      "other": "फील्ड नोट"
     }
   },
   "OrganArticle": {
     "breadcrumbAll": "सभी ऑर्गन",
-    "fieldNote": "फ़ील्ड नोट",
+    "fieldNote": "फील्ड नोट",
     "previousVisit": "← पिछली यात्रा",
     "nextVisit": "अगली यात्रा →",
     "endOfJournal": "— जर्नल का अंत —",
-    "minRead": "{count, plural, one {# मिनट का पठन} other {# मिनट का पठन}}"
+    "minRead": "{count, plural, one {# मिनट पढ़ें} other {# मिनट पढ़ें}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
-    "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "openMenu": "मेन्यू खोलें",
+    "closeMenu": "मेन्यू बंद करें",
+    "wordmarkFallback": "बर्ट वेबिंक",
+    "taglineFallback": "ऑर्गनिस्ट",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "ऑर्गन",
+      "scores": "स्कोर",
+      "about": "मेरे बारे में",
+      "elsewhere": "अन्यत्र"
     }
   },
   "Footer": {
-    "copyright": "© Bert Webbink, {year}",
+    "copyright": "© बर्ट वेबिंक, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "privacy": "निजता",
+      "elsewhere": "अन्यत्र",
+      "contact": "संपर्क"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "home": "होम",
+    "organs": "ऑर्गन",
+    "journal": "जर्नल",
+    "scores": "स्कोर",
+    "about": "परिचय",
+    "elsewhere": "अन्यत्र",
+    "privacy": "निजता"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "भाषा",
+    "switchTo": "{language} पर स्विच करें"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "जर्नल",
+      "description": "निबंध, अंश, अधूरे विचार — तब प्रकाशित होते हैं जब कुछ कहने लायक होता है।"
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "ऑर्गन",
+      "description": "नीदरलैंड और उसके बाहर देखे गए ऑर्गन से फ़ील्ड नोट्स।"
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "स्कोर",
+      "description": "बर्ट वेबिंक द्वारा तैयार किए गए ऑर्गन स्कोर के वर्किंग एडिशन — फिंगरिंग, रजिस्ट्रेशन, गैर-व्यावसायिक अध्ययन के लिए मुफ्त डाउनलोड।"
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "मेरे बारे में",
+      "description": "बर्ट वेबिंक — ऑर्गनिस्ट, शिक्षक, पुरानी इमारतों का शांत आगंतुक।"
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "अन्यत्र",
+      "description": "चुने हुए लिंक — गायक मंडल, चर्च, ऑर्गन संसाधन।"
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "निजता",
+      "description": "इस साइट पर आने पर क्या लॉग किया जाता है, इसके बारे में एक संक्षिप्त, सरल भाषा में नोट।"
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "निर्माणाधीन",
+    "subtitle": "जल्द ही वापस आएँ।"
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "फ़ील्ड नोट्स",
+    "kickerRightFallback": "ऑर्गन लॉफ़्ट से",
+    "headingFallback": "{{पुराने ऑर्गन}} की यात्राएँ",
+    "taglineFallback": "नीदरलैंड और उसके बाहर से हर शनिवार को इकट्ठा की गई रिकॉर्डिंग, तस्वीरें और रजिस्टर।",
+    "cornerLeftSubFallback": "एक फ़ील्ड जर्नल",
+    "cornerRightSubFallback": "निम्न देश",
+    "stats": "{firstYear} से · {totalCount} ऑर्गन"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "लेखन",
+    "kickerRightFallback": "एक फ़ील्ड जर्नल",
+    "headingFallback": "{{जर्नल}}",
+    "taglineFallback": "निबंध, अंश, अधूरे विचार — जब कुछ कहने लायक होता है तब प्रकाशित होते हैं, आमतौर पर जब किसी बेंच ने मेरा मन बदल दिया हो।",
+    "cornerLeftSubFallback": "यात्राओं के बीच के नोट्स",
+    "cornerRightSubFallback": "निम्न देश",
+    "stats": "{firstYear} से · {totalCount} प्रविष्टियाँ"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "संग्रह",
+    "filteredTitle": "<city>{city}</city> में यात्राएँ",
+    "byCity": "शहर के अनुसार",
+    "browseAll": "सभी ब्राउज़ करें →",
+    "shownOfTotal": "{total} में से {shown}",
+    "clearFilter": "फ़िल्टर साफ़ करें ✕",
+    "loading": "लोड हो रहा है…",
+    "endOfArchive": "— संग्रह का अंत —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
-    "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "readMore": "और पढ़ें",
+    "audioFragment": "ऑडियो अंश",
+    "video": "वीडियो",
+    "placeholderLabel": "ऑर्गन की तस्वीर"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "फ़िल्टर",
+    "all": "सभी",
     "categories": {
-      "travelogue": "Travel",
-      "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "travelogue": "यात्रा",
+      "workshop": "कार्यशाला",
+      "memorial": "स्मृति",
+      "home-organ": "घरेलू ऑर्गन",
+      "biography": "जीवनी",
+      "news": "समाचार",
+      "collection": "संग्रह",
+      "other": "अन्य"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "यात्रा वृत्तांत",
+      "workshop": "यात्रा",
+      "memorial": "स्मृति",
+      "home-organ": "घरेलू ऑर्गन",
+      "biography": "जीवनी",
+      "news": "समाचार",
+      "collection": "संग्रह",
+      "other": "नोट"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count, plural, one {# प्रविष्टि} other {# प्रविष्टियाँ}}",
+    "emptyCategory": "इस श्रेणी में अभी कुछ भी नहीं है।",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← नए",
+      "older": "पुराने →",
+      "pageOf": "पेज {current} / {total}"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "ऑडियो है",
+    "readEntry": "प्रविष्टि पढ़ें",
+    "minRead": "{count, plural, one {# मिनट का पठन} other {# मिनट का पठन}}"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "विनिर्देश",
+    "manuals": "मैनुअल",
+    "stops": "स्टॉप",
+    "pitch": "पिच",
+    "temperament": "टेम्परामेंट",
+    "action": "एक्शन",
+    "couplings": "कपलिंग",
+    "accessories": "एक्सेसरीज़",
+    "built": "{year} में निर्मित",
+    "restored": "{year} में पुनर्स्थापित"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "सभी",
+      "baroque": "बैरोक",
+      "dutch": "डच स्कूल",
+      "romantic": "रोमांटिक",
+      "modern": "आधुनिक",
+      "arrangement": "व्यवस्थाएँ"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "संगीतकार",
+      "year": "वर्ष",
+      "edition": "संस्करण №"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
-    "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "headerKickerFallback": "एक छोटी लाइब्रेरी",
+    "headerHeadingFallback": "संस्करण, फिंगरिंग, {{वर्किंग स्कोर}}।",
+    "headerTaglineFallback": "मेरे अपने उपयोग के लिए तैयार किए गए वर्किंग एडिशन — ज़्यादातर फ़ील्ड नोट्स में देखे गए विशिष्ट उपकरणों के लिए। फिंगरिंग और रजिस्ट्रेशन सुझाव हैं, निर्देश नहीं। सभी स्कोर गैर-व्यावसायिक अध्ययन के लिए मुफ्त डाउनलोड किए जा सकते हैं।",
+    "noticeBodyFallback": "ये स्कोर व्यक्तिगत अध्ययन और चर्च के उपयोग के लिए साझा किए गए हैं। यदि आप किसी एक का प्रदर्शन या रिकॉर्ड करना चाहते हैं, तो एक संक्षिप्त ईमेल की सराहना की जाएगी — और कृपया संस्करण को श्रेय दें।",
+    "noticeEditionLineFallback": "संस्करण वेबिंक",
+    "writeToMe": "मुझे लिखें",
+    "emptyTitle": "लाइब्रेरी अभी स्थापित की जा रही है।",
+    "emptyBody": "जैसे ही मैं उन्हें तैयार करूँगा, संस्करण यहाँ दिखाई देंगे। वापस जाँचें, या नीचे मुझे लिखें।",
+    "editionsCount": "{count, plural, one {# संस्करण} other {# संस्करण}}",
+    "sort": "क्रमबद्ध करें: {label}",
+    "period": "अवधि",
+    "download": "डाउनलोड करें",
+    "feature": "विशेष संस्करण",
+    "featuredHeader": "विशेष संस्करण",
+    "editionNumber": "नं. {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "कैटलॉग",
+      "period": "अवधि",
+      "pages": "पेज",
+      "edition": "संस्करण"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "downloadPdf": "PDF डाउनलोड करें",
+    "noPdfYet": "अभी तक कोई PDF नहीं",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "pagesShort": "{count} पृष्ठ",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "जल्द ही",
+    "libraryHeading": "<em>लाइब्रेरी</em>",
+    "showing": "{total} में से {shown} दिखा रहा है",
+    "emptyFilter": "इस श्रेणी में अभी कुछ भी नहीं है — दूसरा फ़िल्टर आज़माएँ।"
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "मेरे बारे में",
+    "emptyBody": "यह पेज अभी तक स्टूडियो में सेट नहीं किया गया है।",
+    "emptyHint": "सामग्री जोड़ने के लिए <code>/admin → About page</code> खोलें।",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "यात्रा",
+    "trajectoryHeading": "एक संक्षिप्त <em>कालक्रम</em> — मैं यहाँ कैसे पहुँचा।",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "मैं क्या बजाता हूँ",
+    "repertoireHeading": "रेपर्टरी जिस पर मैं <em>वापस आता रहता हूँ</em>।"
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "निजता",
+    "emptyBody": "यह पेज अभी तक स्टूडियो में सेट नहीं किया गया है।",
+    "emptyHint": "सामग्री जोड़ने के लिए <code>/admin → Privacy page</code> खोलें।",
+    "lastUpdated": "अंतिम अपडेट {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "अन्यत्र",
+    "emptyTitle": "अन्यत्र",
+    "emptyBody": "यह पेज अभी तक स्टूडियो में सेट नहीं किया गया है।",
+    "emptyHint": "लिंक जोड़ने के लिए <code>/admin → Elsewhere page</code> खोलें।",
+    "noLinks": "अभी तक कोई लिंक नहीं।"
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "जर्नल",
+    "previousEntry": "← पिछली प्रविष्टि",
+    "nextEntry": "अगली प्रविष्टि →",
+    "endOfJournal": "— जर्नल का अंत —",
+    "minRead": "{count, plural, one {# मिनट का पठन} other {# मिनट का पठन}}",
     "categories": {
-      "travelogue": "Travelogue",
-      "workshop": "Workshop",
-      "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "travelogue": "यात्रा वृत्तांत",
+      "workshop": "कार्यशाला",
+      "memorial": "स्मृति में",
+      "home-organ": "घरेलू ऑर्गन",
+      "biography": "जीवनी",
+      "news": "समाचार",
+      "collection": "संग्रह",
+      "other": "फ़ील्ड नोट"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "सभी ऑर्गन",
+    "fieldNote": "फ़ील्ड नोट",
+    "previousVisit": "← पिछली यात्रा",
+    "nextVisit": "अगली यात्रा →",
+    "endOfJournal": "— जर्नल का अंत —",
+    "minRead": "{count, plural, one {# मिनट का पठन} other {# मिनट का पठन}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/it.json
+++ b/messages/it.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
+    "openMenu": "Apri menu",
+    "closeMenu": "Chiudi menu",
     "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "taglineFallback": "Organista",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "Organi",
+      "scores": "Partiture",
+      "about": "Chi sono",
+      "elsewhere": "Altrove"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
       "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "elsewhere": "Altrove",
+      "contact": "Contatti"
     }
   },
   "Crumbs": {
     "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
+    "organs": "Organi",
+    "journal": "Diario",
+    "scores": "Partiture",
+    "about": "Chi sono",
+    "elsewhere": "Altrove",
     "privacy": "Privacy"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "Lingua",
+    "switchTo": "Passa a {language}"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "Diario",
+      "description": "Saggi, frammenti, pensieri incompleti — pubblicati quando c'è qualcosa che vale la pena dire."
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "Organi",
+      "description": "Appunti sul campo dagli organi visitati nei Paesi Bassi e oltre."
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "Partiture",
+      "description": "Edizioni di lavoro di partiture per organo preparate da Bert Webbink — diteggiature, registrazioni, scaricabili gratuitamente per studio non commerciale."
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "Chi sono",
+      "description": "Bert Webbink — organista, insegnante, visitatore silenzioso di edifici antichi."
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "Altrove",
+      "description": "Link selezionati — cori, chiese, risorse per organo."
     },
     "privacy": {
       "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "description": "Una breve nota in linguaggio semplice su ciò che viene registrato quando visiti questo sito."
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "In costruzione",
+    "subtitle": "Torna presto."
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "Appunti sul campo",
+    "kickerRightFallback": "Dalla cantoria",
+    "headingFallback": "Visite a {{organi antichi}}",
+    "taglineFallback": "Registrazioni, fotografie e registri, un sabato alla volta, raccolti nei Paesi Bassi e oltre.",
+    "cornerLeftSubFallback": "Un diario sul campo",
+    "cornerRightSubFallback": "I Paesi Bassi",
+    "stats": "Dal {firstYear} · {totalCount} organi"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "Scritti",
+    "kickerRightFallback": "Un diario sul campo",
+    "headingFallback": "Il {{Diario}}",
+    "taglineFallback": "Saggi, frammenti, pensieri incompleti — pubblicati quando c'è qualcosa che vale la pena dire, di solito dopo che una panca mi ha fatto cambiare idea su qualcosa.",
+    "cornerLeftSubFallback": "Note tra una visita e l'altra",
+    "cornerRightSubFallback": "I Paesi Bassi",
+    "stats": "Dal {firstYear} · {totalCount} articoli"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "L'archivio",
+    "filteredTitle": "Visite a <city>{city}</city>",
+    "byCity": "Per città",
+    "browseAll": "Sfoglia tutto →",
+    "shownOfTotal": "{shown} di {total}",
+    "clearFilter": "cancella filtro ✕",
+    "loading": "Caricamento...",
+    "endOfArchive": "— fine dell'archivio —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
+    "readMore": "Leggi di più",
+    "audioFragment": "Frammento audio",
     "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "placeholderLabel": "fotografia dell'organo"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "Filtra",
+    "all": "Tutti",
     "categories": {
-      "travelogue": "Travel",
+      "travelogue": "Viaggi",
       "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "memorial": "In memoria",
+      "home-organ": "Organo domestico",
+      "biography": "Biografia",
+      "news": "Notizie",
+      "collection": "Collezione",
+      "other": "Altro"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "diario di viaggio",
+      "workshop": "visita",
+      "memorial": "in memoria",
+      "home-organ": "organo domestico",
+      "biography": "biografia",
+      "news": "notizie",
+      "collection": "collezione",
+      "other": "nota"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count, plural, one {# articolo} other {# articoli}}",
+    "emptyCategory": "Niente in questa categoria per ora.",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← Più recenti",
+      "older": "Meno recenti →",
+      "pageOf": "Pagina {current} di {total}"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "Con audio",
+    "readEntry": "Leggi l'articolo",
+    "minRead": "{count, plural, one {# min di lettura} other {# min di lettura}}"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "Disposizione fonica",
+    "manuals": "Manuali",
+    "stops": "Registri",
+    "pitch": "Corista",
+    "temperament": "Temperamento",
+    "action": "Trasmissione",
+    "couplings": "Unioni",
+    "accessories": "Accessori",
+    "built": "Costruito nel {year}",
+    "restored": "Restaurato nel {year}"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "Tutti",
+      "baroque": "Barocco",
+      "dutch": "Scuola olandese",
+      "romantic": "Romantico",
+      "modern": "Moderno",
+      "arrangement": "Arrangiamenti"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "Compositore",
+      "year": "Anno",
+      "edition": "Edizione n."
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
+    "headerKickerFallback": "Una piccola biblioteca",
+    "headerHeadingFallback": "Edizioni, diteggiature, {{partiture di lavoro}}.",
+    "headerTaglineFallback": "Edizioni di lavoro che ho preparato per uso personale — la maggior parte per strumenti specifici visitati negli appunti sul campo. Diteggiature e registrazioni sono suggerimenti, non prescrizioni. Tutte le partiture sono scaricabili gratuitamente per studio non commerciale.",
+    "noticeBodyFallback": "Queste partiture sono condivise per lo studio personale e l'uso liturgico. Se desideri eseguirne o registrarne una, una breve email è apprezzata — e per favore cita l'edizione.",
+    "noticeEditionLineFallback": "Edizione Webbink",
+    "writeToMe": "Scrivimi",
+    "emptyTitle": "La biblioteca è in fase di allestimento.",
+    "emptyBody": "Le edizioni appariranno qui man mano che le preparo. Torna a controllare o scrivimi qui sotto.",
+    "editionsCount": "{count, plural, one {# edizione} other {# edizioni}}",
+    "sort": "Ordina: {label}",
+    "period": "Periodo",
     "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "feature": "Edizione in primo piano",
+    "featuredHeader": "Edizione in primo piano",
+    "editionNumber": "N. {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "Catalogo",
+      "period": "Periodo",
+      "pages": "Pagine",
+      "edition": "Edizione"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "downloadPdf": "Scarica PDF",
+    "noPdfYet": "Nessun PDF ancora",
     "editionLineSuffix": "· {year}",
     "pagesShort": "{count} pp",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "presto",
+    "libraryHeading": "La <em>biblioteca</em>",
+    "showing": "Mostrando {shown} di {total}",
+    "emptyFilter": "Niente in questa categoria per ora — prova un altro filtro."
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "Chi sono",
+    "emptyBody": "Questa pagina non è ancora stata impostata nello Studio.",
+    "emptyHint": "Apri <code>/admin → Pagina Chi sono</code> per aggiungere il contenuto.",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "Percorso",
+    "trajectoryHeading": "Una breve <em>cronologia</em> — come sono arrivato qui.",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "Cosa suono",
+    "repertoireHeading": "Repertorio a cui <em>continuo a tornare</em>."
   },
   "Privacy": {
     "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyBody": "Questa pagina non è ancora stata impostata nello Studio.",
+    "emptyHint": "Apri <code>/admin → Pagina Privacy</code> per aggiungere il contenuto.",
+    "lastUpdated": "Ultimo aggiornamento {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "Altrove",
+    "emptyTitle": "Altrove",
+    "emptyBody": "Questa pagina non è ancora stata impostata nello Studio.",
+    "emptyHint": "Apri <code>/admin → Pagina Altrove</code> per aggiungere link.",
+    "noLinks": "Nessun link ancora."
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "Il diario",
+    "previousEntry": "← Articolo precedente",
+    "nextEntry": "Articolo successivo →",
+    "endOfJournal": "— fine del diario —",
+    "minRead": "{count, plural, one {# min di lettura} other {# min di lettura}}",
     "categories": {
-      "travelogue": "Travelogue",
+      "travelogue": "Diario di viaggio",
       "workshop": "Workshop",
       "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "home-organ": "Organo domestico",
+      "biography": "Biografia",
+      "news": "Notizie",
+      "collection": "Collezione",
+      "other": "Appunto sul campo"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "Tutti gli organi",
+    "fieldNote": "Appunto sul campo",
+    "previousVisit": "← Visita precedente",
+    "nextVisit": "Visita successiva →",
+    "endOfJournal": "— fine del diario —",
+    "minRead": "{count, plural, one {# min di lettura} other {# min di lettura}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/it.json
+++ b/messages/it.json
@@ -6,7 +6,7 @@
     "taglineFallback": "Organista",
     "items": {
       "organs": "Organi",
-      "scores": "Partiture",
+      "scores": "Spartiti",
       "about": "Chi sono",
       "elsewhere": "Altrove"
     }
@@ -23,7 +23,7 @@
     "home": "Home",
     "organs": "Organi",
     "journal": "Diario",
-    "scores": "Partiture",
+    "scores": "Spartiti",
     "about": "Chi sono",
     "elsewhere": "Altrove",
     "privacy": "Privacy"
@@ -35,19 +35,19 @@
   "Metadata": {
     "journal": {
       "title": "Diario",
-      "description": "Saggi, frammenti, pensieri incompleti — pubblicati quando c'è qualcosa che vale la pena dire."
+      "description": "Saggi, frammenti, pensieri incompiuti — pubblicati quando c'è qualcosa che vale la pena dire."
     },
     "organs": {
       "title": "Organi",
-      "description": "Appunti sul campo dagli organi visitati nei Paesi Bassi e oltre."
+      "description": "Appunti di viaggio da organi visitati nei Paesi Bassi e oltre."
     },
     "scores": {
-      "title": "Partiture",
-      "description": "Edizioni di lavoro di partiture per organo preparate da Bert Webbink — diteggiature, registrazioni, scaricabili gratuitamente per studio non commerciale."
+      "title": "Spartiti",
+      "description": "Edizioni di lavoro di spartiti per organo preparate da Bert Webbink — diteggiature, registrazioni, scaricabili gratuitamente per studio non commerciale."
     },
     "about": {
       "title": "Chi sono",
-      "description": "Bert Webbink — organista, insegnante, visitatore silenzioso di edifici antichi."
+      "description": "Bert Webbink — organista, insegnante, tranquillo visitatore di vecchi edifici."
     },
     "elsewhere": {
       "title": "Altrove",
@@ -55,7 +55,7 @@
     },
     "privacy": {
       "title": "Privacy",
-      "description": "Una breve nota in linguaggio semplice su ciò che viene registrato quando visiti questo sito."
+      "description": "Una breve nota in linguaggio semplice su cosa viene registrato quando visiti questo sito."
     }
   },
   "UnderConstruction": {
@@ -63,22 +63,22 @@
     "subtitle": "Torna presto."
   },
   "Hero": {
-    "kickerLeftFallback": "Appunti sul campo",
+    "kickerLeftFallback": "Appunti di viaggio",
     "kickerRightFallback": "Dalla cantoria",
-    "headingFallback": "Visite a {{organi antichi}}",
-    "taglineFallback": "Registrazioni, fotografie e registri, un sabato alla volta, raccolti nei Paesi Bassi e oltre.",
-    "cornerLeftSubFallback": "Un diario sul campo",
+    "headingFallback": "Visite a {{vecchi organi}}",
+    "taglineFallback": "Registrazioni, fotografie e registri da un sabato alla volta, raccolti nei Paesi Bassi e oltre.",
+    "cornerLeftSubFallback": "Un diario di viaggio",
     "cornerRightSubFallback": "I Paesi Bassi",
     "stats": "Dal {firstYear} · {totalCount} organi"
   },
   "JournalHero": {
     "kickerLeftFallback": "Scritti",
-    "kickerRightFallback": "Un diario sul campo",
+    "kickerRightFallback": "Un diario di viaggio",
     "headingFallback": "Il {{Diario}}",
-    "taglineFallback": "Saggi, frammenti, pensieri incompleti — pubblicati quando c'è qualcosa che vale la pena dire, di solito dopo che una panca mi ha fatto cambiare idea su qualcosa.",
+    "taglineFallback": "Saggi, frammenti, pensieri incompiuti — pubblicati quando c'è qualcosa che vale la pena dire, di solito dopo che una panca mi ha fatto cambiare idea su qualcosa.",
     "cornerLeftSubFallback": "Note tra una visita e l'altra",
     "cornerRightSubFallback": "I Paesi Bassi",
-    "stats": "Dal {firstYear} · {totalCount} articoli"
+    "stats": "Dal {firstYear} · {totalCount} voci"
   },
   "OrgansArchive": {
     "title": "L'archivio",
@@ -87,7 +87,7 @@
     "browseAll": "Sfoglia tutto →",
     "shownOfTotal": "{shown} di {total}",
     "clearFilter": "cancella filtro ✕",
-    "loading": "Caricamento...",
+    "loading": "Caricamento…",
     "endOfArchive": "— fine dell'archivio —"
   },
   "OrganCard": {
@@ -100,9 +100,9 @@
     "filter": "Filtra",
     "all": "Tutti",
     "categories": {
-      "travelogue": "Viaggi",
+      "travelogue": "Viaggio",
       "workshop": "Workshop",
-      "memorial": "In memoria",
+      "memorial": "Commemorazione",
       "home-organ": "Organo domestico",
       "biography": "Biografia",
       "news": "Notizie",
@@ -112,32 +112,32 @@
     "categoryKinds": {
       "travelogue": "diario di viaggio",
       "workshop": "visita",
-      "memorial": "in memoria",
+      "memorial": "commemorazione",
       "home-organ": "organo domestico",
       "biography": "biografia",
       "news": "notizie",
       "collection": "collezione",
       "other": "nota"
     },
-    "entriesCount": "{count, plural, one {# articolo} other {# articoli}}",
-    "emptyCategory": "Niente in questa categoria per ora.",
+    "entriesCount": "{count, plural, one {# voce} other {# voci}}",
+    "emptyCategory": "Ancora niente in questa categoria.",
     "pagination": {
       "newer": "← Più recenti",
       "older": "Meno recenti →",
       "pageOf": "Pagina {current} di {total}"
     },
     "hasAudio": "Con audio",
-    "readEntry": "Leggi l'articolo",
+    "readEntry": "Leggi voce",
     "minRead": "{count, plural, one {# min di lettura} other {# min di lettura}}"
   },
   "Specs": {
-    "specification": "Disposizione fonica",
+    "specification": "Specifiche",
     "manuals": "Manuali",
     "stops": "Registri",
-    "pitch": "Corista",
+    "pitch": "Intonazione",
     "temperament": "Temperamento",
-    "action": "Trasmissione",
-    "couplings": "Unioni",
+    "action": "Meccanica",
+    "couplings": "Accoppiamenti",
     "accessories": "Accessori",
     "built": "Costruito nel {year}",
     "restored": "Restaurato nel {year}"
@@ -154,22 +154,22 @@
     "sortBy": {
       "composer": "Compositore",
       "year": "Anno",
-      "edition": "Edizione n."
+      "edition": "Edizione №"
     },
     "headerKickerFallback": "Una piccola biblioteca",
-    "headerHeadingFallback": "Edizioni, diteggiature, {{partiture di lavoro}}.",
-    "headerTaglineFallback": "Edizioni di lavoro che ho preparato per uso personale — la maggior parte per strumenti specifici visitati negli appunti sul campo. Diteggiature e registrazioni sono suggerimenti, non prescrizioni. Tutte le partiture sono scaricabili gratuitamente per studio non commerciale.",
-    "noticeBodyFallback": "Queste partiture sono condivise per lo studio personale e l'uso liturgico. Se desideri eseguirne o registrarne una, una breve email è apprezzata — e per favore cita l'edizione.",
+    "headerHeadingFallback": "Edizioni, diteggiature, {{spartiti di lavoro}}.",
+    "headerTaglineFallback": "Edizioni di lavoro che ho preparato per mio uso personale — la maggior parte per strumenti specifici visitati negli appunti di viaggio. Diteggiature e registrazioni sono suggerimenti, non prescrizioni. Tutti gli spartiti sono scaricabili gratuitamente per studio non commerciale.",
+    "noticeBodyFallback": "Questi spartiti sono condivisi per studio personale e uso ecclesiastico. Se desideri eseguirne o registrarne uno, una breve email è gradita — e per favore cita l'edizione.",
     "noticeEditionLineFallback": "Edizione Webbink",
     "writeToMe": "Scrivimi",
     "emptyTitle": "La biblioteca è in fase di allestimento.",
-    "emptyBody": "Le edizioni appariranno qui man mano che le preparo. Torna a controllare o scrivimi qui sotto.",
+    "emptyBody": "Le edizioni appariranno qui man mano che le preparo. Controlla di nuovo, o scrivimi qui sotto.",
     "editionsCount": "{count, plural, one {# edizione} other {# edizioni}}",
     "sort": "Ordina: {label}",
     "period": "Periodo",
-    "download": "Download",
-    "feature": "Edizione in primo piano",
-    "featuredHeader": "Edizione in primo piano",
+    "download": "Scarica",
+    "feature": "Edizione in evidenza",
+    "featuredHeader": "Edizione in evidenza",
     "editionNumber": "N. {number}",
     "meta": {
       "catalog": "Catalogo",
@@ -178,43 +178,43 @@
       "edition": "Edizione"
     },
     "downloadPdf": "Scarica PDF",
-    "noPdfYet": "Nessun PDF ancora",
+    "noPdfYet": "Ancora nessun PDF",
     "editionLineSuffix": "· {year}",
     "pagesShort": "{count} pp",
     "pdfTag": "PDF",
     "comingSoon": "presto",
     "libraryHeading": "La <em>biblioteca</em>",
-    "showing": "Mostrando {shown} di {total}",
-    "emptyFilter": "Niente in questa categoria per ora — prova un altro filtro."
+    "showing": "Mostra {shown} di {total}",
+    "emptyFilter": "Ancora niente in questa categoria — prova un altro filtro."
   },
   "About": {
     "emptyTitle": "Chi sono",
-    "emptyBody": "Questa pagina non è ancora stata impostata nello Studio.",
-    "emptyHint": "Apri <code>/admin → Pagina Chi sono</code> per aggiungere il contenuto.",
+    "emptyBody": "Questa pagina non è ancora stata configurata nello Studio.",
+    "emptyHint": "Apri <code>/admin → About page</code> per aggiungere il contenuto.",
     "trajectoryNum": "01",
     "trajectoryLabel": "Percorso",
     "trajectoryHeading": "Una breve <em>cronologia</em> — come sono arrivato qui.",
     "repertoireNum": "02",
     "repertoireLabel": "Cosa suono",
-    "repertoireHeading": "Repertorio a cui <em>continuo a tornare</em>."
+    "repertoireHeading": "Repertorio a cui <em>torno sempre</em>."
   },
   "Privacy": {
     "emptyTitle": "Privacy",
-    "emptyBody": "Questa pagina non è ancora stata impostata nello Studio.",
-    "emptyHint": "Apri <code>/admin → Pagina Privacy</code> per aggiungere il contenuto.",
+    "emptyBody": "Questa pagina non è ancora stata configurata nello Studio.",
+    "emptyHint": "Apri <code>/admin → Privacy page</code> per aggiungere il contenuto.",
     "lastUpdated": "Ultimo aggiornamento {date}"
   },
   "Elsewhere": {
     "title": "Altrove",
     "emptyTitle": "Altrove",
-    "emptyBody": "Questa pagina non è ancora stata impostata nello Studio.",
-    "emptyHint": "Apri <code>/admin → Pagina Altrove</code> per aggiungere link.",
-    "noLinks": "Nessun link ancora."
+    "emptyBody": "Questa pagina non è ancora stata configurata nello Studio.",
+    "emptyHint": "Apri <code>/admin → Elsewhere page</code> per aggiungere i link.",
+    "noLinks": "Ancora nessun link."
   },
   "JournalArticle": {
     "breadcrumbHome": "Il diario",
-    "previousEntry": "← Articolo precedente",
-    "nextEntry": "Articolo successivo →",
+    "previousEntry": "← Voce precedente",
+    "nextEntry": "Voce successiva →",
     "endOfJournal": "— fine del diario —",
     "minRead": "{count, plural, one {# min di lettura} other {# min di lettura}}",
     "categories": {
@@ -225,12 +225,12 @@
       "biography": "Biografia",
       "news": "Notizie",
       "collection": "Collezione",
-      "other": "Appunto sul campo"
+      "other": "Nota di campo"
     }
   },
   "OrganArticle": {
     "breadcrumbAll": "Tutti gli organi",
-    "fieldNote": "Appunto sul campo",
+    "fieldNote": "Nota di campo",
     "previousVisit": "← Visita precedente",
     "nextVisit": "Visita successiva →",
     "endOfJournal": "— fine del diario —",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -2,20 +2,20 @@
   "Nav": {
     "openMenu": "メニューを開く",
     "closeMenu": "メニューを閉じる",
-    "wordmarkFallback": "ベルト・ウェビンク",
+    "wordmarkFallback": "バート・ウェビンク",
     "taglineFallback": "オルガニスト",
     "items": {
       "organs": "オルガン",
       "scores": "楽譜",
-      "about": "プロフィール",
-      "elsewhere": "リンク"
+      "about": "私について",
+      "elsewhere": "その他"
     }
   },
   "Footer": {
-    "copyright": "© ベルト・ウェビンク, {year}",
+    "copyright": "© バート・ウェビンク、{year}",
     "links": {
-      "privacy": "プライバシーポリシー",
-      "elsewhere": "リンク",
+      "privacy": "プライバシー",
+      "elsewhere": "その他",
       "contact": "お問い合わせ"
     }
   },
@@ -24,18 +24,18 @@
     "organs": "オルガン",
     "journal": "ジャーナル",
     "scores": "楽譜",
-    "about": "プロフィール",
-    "elsewhere": "リンク",
-    "privacy": "プライバシーポリシー"
+    "about": "について",
+    "elsewhere": "その他",
+    "privacy": "プライバシー"
   },
   "LanguagePicker": {
     "label": "言語",
-    "switchTo": "{language}に切り替え"
+    "switchTo": "{language}に切り替える"
   },
   "Metadata": {
     "journal": {
       "title": "ジャーナル",
-      "description": "エッセイ、断片、未完成の思索 — 語るべきことがあるときに公開。"
+      "description": "エッセイ、断片、未完成の思考 — 語る価値のあるものがあるときに公開されます。"
     },
     "organs": {
       "title": "オルガン",
@@ -43,67 +43,67 @@
     },
     "scores": {
       "title": "楽譜",
-      "description": "ベルト・ウェビンクが作成したオルガン楽譜の実用版 — 運指、レジストレーション付き。非商用研究目的で無料ダウンロード可能。"
+      "description": "バート・ウェビンクが作成したオルガン楽譜の作業版 — 運指、レジストレーション、非営利学習のために無料でダウンロードできます。"
     },
     "about": {
-      "title": "プロフィール",
-      "description": "ベルト・ウェビンク — オルガニスト、教師、古い建物を静かに訪れる人。"
+      "title": "私について",
+      "description": "バート・ウェビンク — オルガニスト、教師、古い建物の静かな訪問者。"
     },
     "elsewhere": {
-      "title": "リンク",
-      "description": "厳選リンク集 — 聖歌隊、教会、オルガン関連資料。"
+      "title": "その他",
+      "description": "厳選されたリンク — 合唱団、教会、オルガン資料。"
     },
     "privacy": {
-      "title": "プライバシーポリシー",
-      "description": "このサイトを訪問した際に記録される情報についての、簡潔で平易な説明。"
+      "title": "プライバシー",
+      "description": "このサイトを訪問した際に何が記録されるかについての、短く平易な言葉での説明。"
     }
   },
   "UnderConstruction": {
-    "title": "準備中",
-    "subtitle": "しばらくお待ちください。"
+    "title": "工事中",
+    "subtitle": "近日中に再訪してください。"
   },
   "Hero": {
     "kickerLeftFallback": "フィールドノート",
     "kickerRightFallback": "オルガンロフトから",
     "headingFallback": "{{古いオルガン}}への訪問",
-    "taglineFallback": "オランダ国内外で、土曜日に少しずつ集めた録音、写真、ストップリスト。",
+    "taglineFallback": "オランダ国内外で、ある土曜日に一度に集められた録音、写真、レジスター。",
     "cornerLeftSubFallback": "フィールドジャーナル",
     "cornerRightSubFallback": "低地諸国",
-    "stats": "{firstYear}年より · {totalCount}台のオルガン"
+    "stats": "{firstYear}年以来 · {totalCount}台のオルガン"
   },
   "JournalHero": {
-    "kickerLeftFallback": "執筆",
+    "kickerLeftFallback": "著作",
     "kickerRightFallback": "フィールドジャーナル",
     "headingFallback": "{{ジャーナル}}",
-    "taglineFallback": "エッセイ、断片、未完成の思索 — 語るべきことがあるときに公開。大抵は、オルガンベンチで何かしらの考えが変わった後に。",
-    "cornerLeftSubFallback": "訪問の合間のノート",
+    "taglineFallback": "エッセイ、断片、未完成の思考 — 語る価値のあるものがあるときに公開されます。通常、ベンチが何かについて私の考えを変えた後に。",
+    "cornerLeftSubFallback": "訪問間のメモ",
     "cornerRightSubFallback": "低地諸国",
-    "stats": "{firstYear}年より · {totalCount}件の記事"
+    "stats": "{firstYear}年以来 · {totalCount}件のエントリー"
   },
   "OrgansArchive": {
     "title": "アーカイブ",
     "filteredTitle": "<city>{city}</city>での訪問",
     "byCity": "都市別",
-    "browseAll": "すべて表示 →",
+    "browseAll": "すべて閲覧 →",
     "shownOfTotal": "{total}件中{shown}件",
     "clearFilter": "フィルターをクリア ✕",
     "loading": "読み込み中…",
-    "endOfArchive": "— アーカイブの終端 —"
+    "endOfArchive": "— アーカイブの終わり —"
   },
   "OrganCard": {
     "readMore": "続きを読む",
     "audioFragment": "音声断片",
     "video": "動画",
-    "placeholderLabel": "オルガンの写真"
+    "placeholderLabel": "オルガン写真"
   },
   "JournalList": {
     "filter": "フィルター",
     "all": "すべて",
     "categories": {
-      "travelogue": "旅行記",
+      "travelogue": "旅行",
       "workshop": "ワークショップ",
       "memorial": "追悼",
-      "home-organ": "自宅オルガン",
+      "home-organ": "ホームオルガン",
       "biography": "伝記",
       "news": "ニュース",
       "collection": "コレクション",
@@ -111,16 +111,16 @@
     },
     "categoryKinds": {
       "travelogue": "旅行記",
-      "workshop": "訪問記",
+      "workshop": "訪問",
       "memorial": "追悼",
-      "home-organ": "自宅オルガン",
+      "home-organ": "ホームオルガン",
       "biography": "伝記",
       "news": "ニュース",
       "collection": "コレクション",
-      "other": "ノート"
+      "other": "メモ"
     },
-    "entriesCount": "{count}件の記事",
-    "emptyCategory": "このカテゴリにはまだ記事がありません。",
+    "entriesCount": "{count}件のエントリー",
+    "emptyCategory": "このカテゴリにはまだ何もありません。",
     "pagination": {
       "newer": "← 新しい記事",
       "older": "古い記事 →",
@@ -128,7 +128,7 @@
     },
     "hasAudio": "音声あり",
     "readEntry": "記事を読む",
-    "minRead": "読了時間: 約{count}分"
+    "minRead": "{count}分で読めます"
   },
   "Specs": {
     "specification": "仕様",
@@ -137,8 +137,8 @@
     "pitch": "ピッチ",
     "temperament": "音律",
     "action": "アクション",
-    "couplings": "カップリング",
-    "accessories": "補助装置",
+    "couplings": "カプリング",
+    "accessories": "付属品",
     "built": "{year}年建造",
     "restored": "{year}年修復"
   },
@@ -148,29 +148,29 @@
       "baroque": "バロック",
       "dutch": "オランダ楽派",
       "romantic": "ロマン派",
-      "modern": "近現代",
+      "modern": "現代",
       "arrangement": "編曲"
     },
     "sortBy": {
       "composer": "作曲家",
-      "year": "年代",
+      "year": "年",
       "edition": "版番号"
     },
     "headerKickerFallback": "小さなライブラリ",
-    "headerHeadingFallback": "版、運指、{{実用楽譜}}。",
-    "headerTaglineFallback": "私が個人用に作成した実用版楽譜です。多くはフィールドノートで訪れた特定の楽器のために用意しました。運指やレジストレーションは提案であり、規定ではありません。すべての楽譜は非商用研究目的で無料ダウンロードできます。",
-    "noticeBodyFallback": "これらの楽譜は個人研究および教会での使用のために共有されています。演奏や録音を希望される場合は、簡単なメールをいただけると幸いです。また、版のクレジット表記をお願いします。",
+    "headerHeadingFallback": "版、運指、{{作業用楽譜}}。",
+    "headerTaglineFallback": "私が個人的な使用のために作成した作業版 — そのほとんどはフィールドノートで訪れた特定の楽器用です。運指とレジストレーションは提案であり、指示ではありません。すべての楽譜は非営利学習のために無料でダウンロードできます。",
+    "noticeBodyFallback": "これらの楽譜は個人的な学習および教会での使用のために共有されています。演奏または録音をご希望の場合は、短いメールをいただけると幸いです — そして、版を明記してください。",
     "noticeEditionLineFallback": "ウェビンク版",
-    "writeToMe": "連絡する",
-    "emptyTitle": "ライブラリは準備中です。",
-    "emptyBody": "楽譜は準備が整い次第、ここに表示されます。後ほど再確認するか、下記よりご連絡ください。",
-    "editionsCount": "{count}版",
+    "writeToMe": "私に連絡する",
+    "emptyTitle": "ライブラリは現在設定中です。",
+    "emptyBody": "準備ができ次第、ここに版が表示されます。後で確認するか、以下から私に連絡してください。",
+    "editionsCount": "{count}件の版",
     "sort": "並べ替え: {label}",
     "period": "時代",
     "download": "ダウンロード",
-    "feature": "おすすめの版",
-    "featuredHeader": "おすすめの版",
-    "editionNumber": "第{number}番",
+    "feature": "特集版",
+    "featuredHeader": "特集版",
+    "editionNumber": "No. {number}",
     "meta": {
       "catalog": "カタログ",
       "period": "時代",
@@ -178,50 +178,50 @@
       "edition": "版"
     },
     "downloadPdf": "PDFをダウンロード",
-    "noPdfYet": "PDF未作成",
-    "editionLineSuffix": "· {year}年",
+    "noPdfYet": "まだPDFはありません",
+    "editionLineSuffix": "· {year}",
     "pagesShort": "{count}ページ",
     "pdfTag": "PDF",
     "comingSoon": "近日公開",
     "libraryHeading": "<em>ライブラリ</em>",
     "showing": "{total}件中{shown}件を表示",
-    "emptyFilter": "このカテゴリにはまだ楽譜がありません — 別のフィルターをお試しください。"
+    "emptyFilter": "このカテゴリにはまだ何もありません — 別のフィルターを試してください。"
   },
   "About": {
-    "emptyTitle": "プロフィール",
-    "emptyBody": "このページはまだStudioで設定されていません。",
-    "emptyHint": "<code>/admin → プロフィールページ</code>を開いてコンテンツを追加してください。",
+    "emptyTitle": "私について",
+    "emptyBody": "このページはまだスタジオで設定されていません。",
+    "emptyHint": "コンテンツを追加するには、<code>/admin → About page</code>を開いてください。",
     "trajectoryNum": "01",
-    "trajectoryLabel": "経歴",
-    "trajectoryHeading": "短い<em>年表</em> — これまでの歩み。",
+    "trajectoryLabel": "軌跡",
+    "trajectoryHeading": "短い<em>年表</em> — 私がここにたどり着くまで。",
     "repertoireNum": "02",
-    "repertoireLabel": "演奏曲目",
-    "repertoireHeading": "何度も<em>立ち返る</em>レパートリー。"
+    "repertoireLabel": "演奏レパートリー",
+    "repertoireHeading": "私が<em>繰り返し演奏する</em>レパートリー。"
   },
   "Privacy": {
-    "emptyTitle": "プライバシーポリシー",
-    "emptyBody": "このページはまだStudioで設定されていません。",
-    "emptyHint": "<code>/admin → プライバシーポリシーページ</code>を開いてコンテンツを追加してください。",
+    "emptyTitle": "プライバシー",
+    "emptyBody": "このページはまだスタジオで設定されていません。",
+    "emptyHint": "コンテンツを追加するには、<code>/admin → Privacy page</code>を開いてください。",
     "lastUpdated": "最終更新日: {date}"
   },
   "Elsewhere": {
-    "title": "リンク",
-    "emptyTitle": "リンク",
-    "emptyBody": "このページはまだStudioで設定されていません。",
-    "emptyHint": "<code>/admin → リンクページ</code>を開いてリンクを追加してください。",
-    "noLinks": "まだリンクがありません。"
+    "title": "その他",
+    "emptyTitle": "その他",
+    "emptyBody": "このページはまだスタジオで設定されていません。",
+    "emptyHint": "リンクを追加するには、<code>/admin → Elsewhere page</code>を開いてください。",
+    "noLinks": "まだリンクはありません。"
   },
   "JournalArticle": {
     "breadcrumbHome": "ジャーナル",
     "previousEntry": "← 前の記事",
     "nextEntry": "次の記事 →",
-    "endOfJournal": "— ジャーナルの終端 —",
-    "minRead": "読了時間: 約{count}分",
+    "endOfJournal": "— ジャーナルの終わり —",
+    "minRead": "{count}分で読めます",
     "categories": {
       "travelogue": "旅行記",
       "workshop": "ワークショップ",
       "memorial": "追悼",
-      "home-organ": "自宅オルガン",
+      "home-organ": "ホームオルガン",
       "biography": "伝記",
       "news": "ニュース",
       "collection": "コレクション",
@@ -233,8 +233,8 @@
     "fieldNote": "フィールドノート",
     "previousVisit": "← 前の訪問",
     "nextVisit": "次の訪問 →",
-    "endOfJournal": "— ジャーナルの終端 —",
-    "minRead": "読了時間: 約{count}分"
+    "endOfJournal": "— ジャーナルの終わり —",
+    "minRead": "{count}分で読めます"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
-    "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "openMenu": "メニューを開く",
+    "closeMenu": "メニューを閉じる",
+    "wordmarkFallback": "ベルト・ウェビンク",
+    "taglineFallback": "オルガニスト",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "オルガン",
+      "scores": "楽譜",
+      "about": "プロフィール",
+      "elsewhere": "リンク"
     }
   },
   "Footer": {
-    "copyright": "© Bert Webbink, {year}",
+    "copyright": "© ベルト・ウェビンク, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "privacy": "プライバシーポリシー",
+      "elsewhere": "リンク",
+      "contact": "お問い合わせ"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "home": "ホーム",
+    "organs": "オルガン",
+    "journal": "ジャーナル",
+    "scores": "楽譜",
+    "about": "プロフィール",
+    "elsewhere": "リンク",
+    "privacy": "プライバシーポリシー"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "言語",
+    "switchTo": "{language}に切り替え"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "ジャーナル",
+      "description": "エッセイ、断片、未完成の思索 — 語るべきことがあるときに公開。"
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "オルガン",
+      "description": "オランダ国内外で訪れたオルガンからのフィールドノート。"
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "楽譜",
+      "description": "ベルト・ウェビンクが作成したオルガン楽譜の実用版 — 運指、レジストレーション付き。非商用研究目的で無料ダウンロード可能。"
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "プロフィール",
+      "description": "ベルト・ウェビンク — オルガニスト、教師、古い建物を静かに訪れる人。"
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "リンク",
+      "description": "厳選リンク集 — 聖歌隊、教会、オルガン関連資料。"
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "プライバシーポリシー",
+      "description": "このサイトを訪問した際に記録される情報についての、簡潔で平易な説明。"
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "準備中",
+    "subtitle": "しばらくお待ちください。"
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "フィールドノート",
+    "kickerRightFallback": "オルガンロフトから",
+    "headingFallback": "{{古いオルガン}}への訪問",
+    "taglineFallback": "オランダ国内外で、土曜日に少しずつ集めた録音、写真、ストップリスト。",
+    "cornerLeftSubFallback": "フィールドジャーナル",
+    "cornerRightSubFallback": "低地諸国",
+    "stats": "{firstYear}年より · {totalCount}台のオルガン"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "執筆",
+    "kickerRightFallback": "フィールドジャーナル",
+    "headingFallback": "{{ジャーナル}}",
+    "taglineFallback": "エッセイ、断片、未完成の思索 — 語るべきことがあるときに公開。大抵は、オルガンベンチで何かしらの考えが変わった後に。",
+    "cornerLeftSubFallback": "訪問の合間のノート",
+    "cornerRightSubFallback": "低地諸国",
+    "stats": "{firstYear}年より · {totalCount}件の記事"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "アーカイブ",
+    "filteredTitle": "<city>{city}</city>での訪問",
+    "byCity": "都市別",
+    "browseAll": "すべて表示 →",
+    "shownOfTotal": "{total}件中{shown}件",
+    "clearFilter": "フィルターをクリア ✕",
+    "loading": "読み込み中…",
+    "endOfArchive": "— アーカイブの終端 —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
-    "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "readMore": "続きを読む",
+    "audioFragment": "音声断片",
+    "video": "動画",
+    "placeholderLabel": "オルガンの写真"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "フィルター",
+    "all": "すべて",
     "categories": {
-      "travelogue": "Travel",
-      "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "travelogue": "旅行記",
+      "workshop": "ワークショップ",
+      "memorial": "追悼",
+      "home-organ": "自宅オルガン",
+      "biography": "伝記",
+      "news": "ニュース",
+      "collection": "コレクション",
+      "other": "その他"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "旅行記",
+      "workshop": "訪問記",
+      "memorial": "追悼",
+      "home-organ": "自宅オルガン",
+      "biography": "伝記",
+      "news": "ニュース",
+      "collection": "コレクション",
+      "other": "ノート"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count}件の記事",
+    "emptyCategory": "このカテゴリにはまだ記事がありません。",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← 新しい記事",
+      "older": "古い記事 →",
+      "pageOf": "{total}ページ中{current}ページ"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "音声あり",
+    "readEntry": "記事を読む",
+    "minRead": "読了時間: 約{count}分"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "仕様",
+    "manuals": "手鍵盤",
+    "stops": "ストップ",
+    "pitch": "ピッチ",
+    "temperament": "音律",
+    "action": "アクション",
+    "couplings": "カップリング",
+    "accessories": "補助装置",
+    "built": "{year}年建造",
+    "restored": "{year}年修復"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "すべて",
+      "baroque": "バロック",
+      "dutch": "オランダ楽派",
+      "romantic": "ロマン派",
+      "modern": "近現代",
+      "arrangement": "編曲"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "作曲家",
+      "year": "年代",
+      "edition": "版番号"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
-    "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "headerKickerFallback": "小さなライブラリ",
+    "headerHeadingFallback": "版、運指、{{実用楽譜}}。",
+    "headerTaglineFallback": "私が個人用に作成した実用版楽譜です。多くはフィールドノートで訪れた特定の楽器のために用意しました。運指やレジストレーションは提案であり、規定ではありません。すべての楽譜は非商用研究目的で無料ダウンロードできます。",
+    "noticeBodyFallback": "これらの楽譜は個人研究および教会での使用のために共有されています。演奏や録音を希望される場合は、簡単なメールをいただけると幸いです。また、版のクレジット表記をお願いします。",
+    "noticeEditionLineFallback": "ウェビンク版",
+    "writeToMe": "連絡する",
+    "emptyTitle": "ライブラリは準備中です。",
+    "emptyBody": "楽譜は準備が整い次第、ここに表示されます。後ほど再確認するか、下記よりご連絡ください。",
+    "editionsCount": "{count}版",
+    "sort": "並べ替え: {label}",
+    "period": "時代",
+    "download": "ダウンロード",
+    "feature": "おすすめの版",
+    "featuredHeader": "おすすめの版",
+    "editionNumber": "第{number}番",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "カタログ",
+      "period": "時代",
+      "pages": "ページ数",
+      "edition": "版"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
-    "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "downloadPdf": "PDFをダウンロード",
+    "noPdfYet": "PDF未作成",
+    "editionLineSuffix": "· {year}年",
+    "pagesShort": "{count}ページ",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "近日公開",
+    "libraryHeading": "<em>ライブラリ</em>",
+    "showing": "{total}件中{shown}件を表示",
+    "emptyFilter": "このカテゴリにはまだ楽譜がありません — 別のフィルターをお試しください。"
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "プロフィール",
+    "emptyBody": "このページはまだStudioで設定されていません。",
+    "emptyHint": "<code>/admin → プロフィールページ</code>を開いてコンテンツを追加してください。",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "経歴",
+    "trajectoryHeading": "短い<em>年表</em> — これまでの歩み。",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "演奏曲目",
+    "repertoireHeading": "何度も<em>立ち返る</em>レパートリー。"
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "プライバシーポリシー",
+    "emptyBody": "このページはまだStudioで設定されていません。",
+    "emptyHint": "<code>/admin → プライバシーポリシーページ</code>を開いてコンテンツを追加してください。",
+    "lastUpdated": "最終更新日: {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "リンク",
+    "emptyTitle": "リンク",
+    "emptyBody": "このページはまだStudioで設定されていません。",
+    "emptyHint": "<code>/admin → リンクページ</code>を開いてリンクを追加してください。",
+    "noLinks": "まだリンクがありません。"
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "ジャーナル",
+    "previousEntry": "← 前の記事",
+    "nextEntry": "次の記事 →",
+    "endOfJournal": "— ジャーナルの終端 —",
+    "minRead": "読了時間: 約{count}分",
     "categories": {
-      "travelogue": "Travelogue",
-      "workshop": "Workshop",
-      "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "travelogue": "旅行記",
+      "workshop": "ワークショップ",
+      "memorial": "追悼",
+      "home-organ": "自宅オルガン",
+      "biography": "伝記",
+      "news": "ニュース",
+      "collection": "コレクション",
+      "other": "フィールドノート"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "すべてのオルガン",
+    "fieldNote": "フィールドノート",
+    "previousVisit": "← 前の訪問",
+    "nextVisit": "次の訪問 →",
+    "endOfJournal": "— ジャーナルの終端 —",
+    "minRead": "読了時間: 約{count}分"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -2,21 +2,21 @@
   "Nav": {
     "openMenu": "메뉴 열기",
     "closeMenu": "메뉴 닫기",
-    "wordmarkFallback": "베르트 베빙크",
+    "wordmarkFallback": "베르트 웨빙크",
     "taglineFallback": "오르가니스트",
     "items": {
       "organs": "오르간",
       "scores": "악보",
       "about": "소개",
-      "elsewhere": "외부 링크"
+      "elsewhere": "다른 곳"
     }
   },
   "Footer": {
-    "copyright": "© 베르트 베빙크, {year}",
+    "copyright": "© 베르트 웨빙크, {year}",
     "links": {
       "privacy": "개인정보처리방침",
-      "elsewhere": "외부 링크",
-      "contact": "연락처"
+      "elsewhere": "다른 곳",
+      "contact": "문의"
     }
   },
   "Crumbs": {
@@ -25,48 +25,48 @@
     "journal": "저널",
     "scores": "악보",
     "about": "소개",
-    "elsewhere": "외부 링크",
+    "elsewhere": "다른 곳",
     "privacy": "개인정보처리방침"
   },
   "LanguagePicker": {
     "label": "언어",
-    "switchTo": "{language}(으)로 전환"
+    "switchTo": "{language}로 전환"
   },
   "Metadata": {
     "journal": {
       "title": "저널",
-      "description": "에세이, 단상, 미완의 생각들 — 할 말이 있을 때 게시됩니다."
+      "description": "에세이, 단편, 미완성 생각 — 할 말이 있을 때 발행됩니다."
     },
     "organs": {
       "title": "오르간",
-      "description": "네덜란드 전역과 그 외 지역에서 방문한 오르간에 대한 현장 기록입니다."
+      "description": "네덜란드 및 그 외 지역에서 방문한 오르간에 대한 현장 기록."
     },
     "scores": {
       "title": "악보",
-      "description": "베르트 베빙크가 준비한 오르간 악보 작업본 — 운지법, 레지스트레이션, 비상업적 학습용으로 무료 다운로드 가능합니다."
+      "description": "베르트 웨빙크가 준비한 오르간 악보 작업판 — 운지법, 레지스트레이션, 비상업적 학습용으로 무료 다운로드 가능."
     },
     "about": {
       "title": "소개",
-      "description": "베르트 베빙크 — 오르가니스트, 교사, 오래된 건물을 조용히 방문하는 사람."
+      "description": "베르트 웨빙크 — 오르가니스트, 교사, 오래된 건물의 조용한 방문객."
     },
     "elsewhere": {
-      "title": "외부 링크",
+      "title": "다른 곳",
       "description": "선별된 링크 — 합창단, 교회, 오르간 자료."
     },
     "privacy": {
       "title": "개인정보처리방침",
-      "description": "이 사이트를 방문할 때 기록되는 내용에 대한 짧고 평이한 설명입니다."
+      "description": "이 사이트 방문 시 기록되는 내용에 대한 짧고 쉬운 설명."
     }
   },
   "UnderConstruction": {
     "title": "공사 중",
-    "subtitle": "곧 다시 방문해 주세요."
+    "subtitle": "곧 다시 방문해주세요."
   },
   "Hero": {
     "kickerLeftFallback": "현장 기록",
     "kickerRightFallback": "오르간 로프트에서",
-    "headingFallback": "{{오래된 오르간}} 방문기",
-    "taglineFallback": "네덜란드와 그 외 지역에서 매주 토요일마다 수집한 녹음, 사진, 레지스터.",
+    "headingFallback": "{{오래된 오르간}} 방문",
+    "taglineFallback": "네덜란드 및 그 외 지역에서 한 번에 한 토요일씩 수집된 녹음, 사진 및 레지스터.",
     "cornerLeftSubFallback": "현장 저널",
     "cornerRightSubFallback": "저지대 국가",
     "stats": "{firstYear}년부터 · 오르간 {totalCount}대"
@@ -74,18 +74,18 @@
   "JournalHero": {
     "kickerLeftFallback": "글",
     "kickerRightFallback": "현장 저널",
-    "headingFallback": "{{저널}}",
-    "taglineFallback": "에세이, 단상, 미완의 생각들 — 할 말이 있을 때, 보통 오르간 의자에 앉아 생각이 바뀐 후에 게시됩니다.",
+    "headingFallback": "그 {{저널}}",
+    "taglineFallback": "에세이, 단편, 미완성 생각 — 할 말이 있을 때, 보통 벤치가 어떤 것에 대한 내 생각을 바꾼 후에 발행됩니다.",
     "cornerLeftSubFallback": "방문 사이의 기록",
     "cornerRightSubFallback": "저지대 국가",
     "stats": "{firstYear}년부터 · 게시물 {totalCount}개"
   },
   "OrgansArchive": {
     "title": "아카이브",
-    "filteredTitle": "<city>{city}</city> 방문기",
+    "filteredTitle": "<city>{city}</city> 방문",
     "byCity": "도시별",
     "browseAll": "모두 보기 →",
-    "shownOfTotal": "{shown}/{total}",
+    "shownOfTotal": "{total}개 중 {shown}개",
     "clearFilter": "필터 지우기 ✕",
     "loading": "로딩 중…",
     "endOfArchive": "— 아카이브 끝 —"
@@ -105,7 +105,7 @@
       "memorial": "추모",
       "home-organ": "가정용 오르간",
       "biography": "전기",
-      "news": "소식",
+      "news": "뉴스",
       "collection": "컬렉션",
       "other": "기타"
     },
@@ -115,12 +115,12 @@
       "memorial": "추모",
       "home-organ": "가정용 오르간",
       "biography": "전기",
-      "news": "소식",
+      "news": "뉴스",
       "collection": "컬렉션",
       "other": "메모"
     },
-    "entriesCount": "게시물 {count}개",
-    "emptyCategory": "이 카테고리에 아직 게시물이 없습니다.",
+    "entriesCount": "{count, plural, one {#개 게시물} other {#개 게시물}}",
+    "emptyCategory": "이 카테고리에는 아직 아무것도 없습니다.",
     "pagination": {
       "newer": "← 최신",
       "older": "이전 →",
@@ -128,16 +128,16 @@
     },
     "hasAudio": "오디오 있음",
     "readEntry": "게시물 읽기",
-    "minRead": "읽는 데 {count}분"
+    "minRead": "{count, plural, one {#분 읽기} other {#분 읽기}}"
   },
   "Specs": {
     "specification": "사양",
-    "manuals": "매뉴얼",
+    "manuals": "건반",
     "stops": "스톱",
-    "pitch": "음고",
-    "temperament": "음률",
+    "pitch": "피치",
+    "temperament": "평균율",
     "action": "액션",
-    "couplings": "커플러",
+    "couplings": "커플링",
     "accessories": "액세서리",
     "built": "{year}년 제작",
     "restored": "{year}년 복원"
@@ -146,7 +146,7 @@
     "filters": {
       "all": "전체",
       "baroque": "바로크",
-      "dutch": "네덜란드 악파",
+      "dutch": "네덜란드 학파",
       "romantic": "낭만주의",
       "modern": "현대",
       "arrangement": "편곡"
@@ -156,21 +156,21 @@
       "year": "연도",
       "edition": "에디션 번호"
     },
-    "headerKickerFallback": "작은 도서관",
-    "headerHeadingFallback": "에디션, 운지법, {{작업용 악보}}.",
-    "headerTaglineFallback": "개인적인 용도로 준비한 작업용 에디션입니다. 대부분은 현장 기록에서 방문한 특정 악기를 위한 것입니다. 운지법과 레지스트레이션은 제안일 뿐, 규정은 아닙니다. 모든 악보는 비상업적 학습용으로 무료로 다운로드할 수 있습니다.",
-    "noticeBodyFallback": "이 악보들은 개인적인 학습 및 교회용으로 공유됩니다. 연주나 녹음을 원하시면 짧은 이메일을 보내주시면 감사하겠습니다. 그리고 에디션 출처를 밝혀주세요.",
-    "noticeEditionLineFallback": "에디션 베빙크",
-    "writeToMe": "메일 보내기",
-    "emptyTitle": "라이브러리를 준비 중입니다.",
-    "emptyBody": "에디션은 준비되는 대로 여기에 표시됩니다. 다시 확인하거나 아래로 메일을 보내주세요.",
-    "editionsCount": "에디션 {count}개",
+    "headerKickerFallback": "작은 라이브러리",
+    "headerHeadingFallback": "에디션, 운지법, {{작업 악보}}.",
+    "headerTaglineFallback": "제가 개인적으로 사용하기 위해 준비한 작업판 — 대부분 현장 기록에서 방문한 특정 악기를 위한 것입니다. 운지법과 레지스트레이션은 제안이며, 필수가 아닙니다. 모든 악보는 비상업적 학습용으로 무료 다운로드 가능합니다.",
+    "noticeBodyFallback": "이 악보들은 개인 학습 및 교회 사용을 위해 공유됩니다. 연주 또는 녹음을 원하시면 짧은 이메일을 보내주시면 감사하겠습니다 — 그리고 에디션을 명시해주세요.",
+    "noticeEditionLineFallback": "웨빙크 에디션",
+    "writeToMe": "저에게 쓰기",
+    "emptyTitle": "라이브러리가 막 설정되는 중입니다.",
+    "emptyBody": "제가 준비하는 대로 에디션이 여기에 나타날 것입니다. 다시 확인하거나 아래에 저에게 써주세요.",
+    "editionsCount": "{count, plural, one {#개 에디션} other {#개 에디션}}",
     "sort": "정렬: {label}",
     "period": "시대",
     "download": "다운로드",
     "feature": "추천 에디션",
     "featuredHeader": "추천 에디션",
-    "editionNumber": "No. {number}",
+    "editionNumber": "번호 {number}",
     "meta": {
       "catalog": "카탈로그",
       "period": "시대",
@@ -182,48 +182,48 @@
     "editionLineSuffix": "· {year}",
     "pagesShort": "{count}쪽",
     "pdfTag": "PDF",
-    "comingSoon": "곧 제공",
-    "libraryHeading": "<em>라이브러리</em>",
-    "showing": "총 {total}개 중 {shown}개 표시",
-    "emptyFilter": "이 카테고리에 아직 항목이 없습니다 — 다른 필터를 시도해 보세요."
+    "comingSoon": "출시 예정",
+    "libraryHeading": "그 <em>라이브러리</em>",
+    "showing": "{total}개 중 {shown}개 표시",
+    "emptyFilter": "이 카테고리에는 아직 아무것도 없습니다 — 다른 필터를 시도해보세요."
   },
   "About": {
     "emptyTitle": "소개",
     "emptyBody": "이 페이지는 아직 스튜디오에서 설정되지 않았습니다.",
-    "emptyHint": "<code>/admin → 소개 페이지</code>를 열어 콘텐츠를 추가하세요.",
+    "emptyHint": "콘텐츠를 추가하려면 <code>/admin → About page</code>를 여세요.",
     "trajectoryNum": "01",
     "trajectoryLabel": "궤적",
-    "trajectoryHeading": "짧은 <em>연대기</em> — 제가 여기까지 온 과정.",
+    "trajectoryHeading": "짧은 <em>연대기</em> — 제가 여기까지 오게 된 과정.",
     "repertoireNum": "02",
-    "repertoireLabel": "연주곡",
-    "repertoireHeading": "제가 계속 <em>다시 연주하는</em> 레퍼토리."
+    "repertoireLabel": "제가 연주하는 것",
+    "repertoireHeading": "제가 계속 <em>다시 찾는</em> 레퍼토리."
   },
   "Privacy": {
     "emptyTitle": "개인정보처리방침",
     "emptyBody": "이 페이지는 아직 스튜디오에서 설정되지 않았습니다.",
-    "emptyHint": "<code>/admin → 개인정보처리방침 페이지</code>를 열어 콘텐츠를 추가하세요.",
-    "lastUpdated": "마지막 업데이트: {date}"
+    "emptyHint": "콘텐츠를 추가하려면 <code>/admin → Privacy page</code>를 여세요.",
+    "lastUpdated": "최종 업데이트 {date}"
   },
   "Elsewhere": {
-    "title": "외부 링크",
-    "emptyTitle": "외부 링크",
+    "title": "다른 곳",
+    "emptyTitle": "다른 곳",
     "emptyBody": "이 페이지는 아직 스튜디오에서 설정되지 않았습니다.",
-    "emptyHint": "<code>/admin → 외부 링크 페이지</code>를 열어 링크를 추가하세요.",
+    "emptyHint": "링크를 추가하려면 <code>/admin → Elsewhere page</code>를 여세요.",
     "noLinks": "아직 링크가 없습니다."
   },
   "JournalArticle": {
     "breadcrumbHome": "저널",
-    "previousEntry": "← 이전 글",
-    "nextEntry": "다음 글 →",
+    "previousEntry": "← 이전 게시물",
+    "nextEntry": "다음 게시물 →",
     "endOfJournal": "— 저널 끝 —",
-    "minRead": "읽는 데 {count}분",
+    "minRead": "{count, plural, one {#분 읽기} other {#분 읽기}}",
     "categories": {
       "travelogue": "여행기",
       "workshop": "워크숍",
       "memorial": "추모",
       "home-organ": "가정용 오르간",
       "biography": "전기",
-      "news": "소식",
+      "news": "뉴스",
       "collection": "컬렉션",
       "other": "현장 기록"
     }
@@ -234,7 +234,7 @@
     "previousVisit": "← 이전 방문",
     "nextVisit": "다음 방문 →",
     "endOfJournal": "— 저널 끝 —",
-    "minRead": "읽는 데 {count}분"
+    "minRead": "{count, plural, one {#분 읽기} other {#분 읽기}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
-    "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "openMenu": "메뉴 열기",
+    "closeMenu": "메뉴 닫기",
+    "wordmarkFallback": "베르트 베빙크",
+    "taglineFallback": "오르가니스트",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "오르간",
+      "scores": "악보",
+      "about": "소개",
+      "elsewhere": "외부 링크"
     }
   },
   "Footer": {
-    "copyright": "© Bert Webbink, {year}",
+    "copyright": "© 베르트 베빙크, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "privacy": "개인정보처리방침",
+      "elsewhere": "외부 링크",
+      "contact": "연락처"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "home": "홈",
+    "organs": "오르간",
+    "journal": "저널",
+    "scores": "악보",
+    "about": "소개",
+    "elsewhere": "외부 링크",
+    "privacy": "개인정보처리방침"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "언어",
+    "switchTo": "{language}(으)로 전환"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "저널",
+      "description": "에세이, 단상, 미완의 생각들 — 할 말이 있을 때 게시됩니다."
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "오르간",
+      "description": "네덜란드 전역과 그 외 지역에서 방문한 오르간에 대한 현장 기록입니다."
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "악보",
+      "description": "베르트 베빙크가 준비한 오르간 악보 작업본 — 운지법, 레지스트레이션, 비상업적 학습용으로 무료 다운로드 가능합니다."
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "소개",
+      "description": "베르트 베빙크 — 오르가니스트, 교사, 오래된 건물을 조용히 방문하는 사람."
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "외부 링크",
+      "description": "선별된 링크 — 합창단, 교회, 오르간 자료."
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "개인정보처리방침",
+      "description": "이 사이트를 방문할 때 기록되는 내용에 대한 짧고 평이한 설명입니다."
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "공사 중",
+    "subtitle": "곧 다시 방문해 주세요."
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "현장 기록",
+    "kickerRightFallback": "오르간 로프트에서",
+    "headingFallback": "{{오래된 오르간}} 방문기",
+    "taglineFallback": "네덜란드와 그 외 지역에서 매주 토요일마다 수집한 녹음, 사진, 레지스터.",
+    "cornerLeftSubFallback": "현장 저널",
+    "cornerRightSubFallback": "저지대 국가",
+    "stats": "{firstYear}년부터 · 오르간 {totalCount}대"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "글",
+    "kickerRightFallback": "현장 저널",
+    "headingFallback": "{{저널}}",
+    "taglineFallback": "에세이, 단상, 미완의 생각들 — 할 말이 있을 때, 보통 오르간 의자에 앉아 생각이 바뀐 후에 게시됩니다.",
+    "cornerLeftSubFallback": "방문 사이의 기록",
+    "cornerRightSubFallback": "저지대 국가",
+    "stats": "{firstYear}년부터 · 게시물 {totalCount}개"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "아카이브",
+    "filteredTitle": "<city>{city}</city> 방문기",
+    "byCity": "도시별",
+    "browseAll": "모두 보기 →",
+    "shownOfTotal": "{shown}/{total}",
+    "clearFilter": "필터 지우기 ✕",
+    "loading": "로딩 중…",
+    "endOfArchive": "— 아카이브 끝 —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
-    "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "readMore": "더 읽기",
+    "audioFragment": "오디오 조각",
+    "video": "비디오",
+    "placeholderLabel": "오르간 사진"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "필터",
+    "all": "전체",
     "categories": {
-      "travelogue": "Travel",
-      "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "travelogue": "여행",
+      "workshop": "워크숍",
+      "memorial": "추모",
+      "home-organ": "가정용 오르간",
+      "biography": "전기",
+      "news": "소식",
+      "collection": "컬렉션",
+      "other": "기타"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "여행기",
+      "workshop": "방문",
+      "memorial": "추모",
+      "home-organ": "가정용 오르간",
+      "biography": "전기",
+      "news": "소식",
+      "collection": "컬렉션",
+      "other": "메모"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "게시물 {count}개",
+    "emptyCategory": "이 카테고리에 아직 게시물이 없습니다.",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← 최신",
+      "older": "이전 →",
+      "pageOf": "{total}페이지 중 {current}페이지"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "오디오 있음",
+    "readEntry": "게시물 읽기",
+    "minRead": "읽는 데 {count}분"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "사양",
+    "manuals": "매뉴얼",
+    "stops": "스톱",
+    "pitch": "음고",
+    "temperament": "음률",
+    "action": "액션",
+    "couplings": "커플러",
+    "accessories": "액세서리",
+    "built": "{year}년 제작",
+    "restored": "{year}년 복원"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "전체",
+      "baroque": "바로크",
+      "dutch": "네덜란드 악파",
+      "romantic": "낭만주의",
+      "modern": "현대",
+      "arrangement": "편곡"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "작곡가",
+      "year": "연도",
+      "edition": "에디션 번호"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
-    "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
+    "headerKickerFallback": "작은 도서관",
+    "headerHeadingFallback": "에디션, 운지법, {{작업용 악보}}.",
+    "headerTaglineFallback": "개인적인 용도로 준비한 작업용 에디션입니다. 대부분은 현장 기록에서 방문한 특정 악기를 위한 것입니다. 운지법과 레지스트레이션은 제안일 뿐, 규정은 아닙니다. 모든 악보는 비상업적 학습용으로 무료로 다운로드할 수 있습니다.",
+    "noticeBodyFallback": "이 악보들은 개인적인 학습 및 교회용으로 공유됩니다. 연주나 녹음을 원하시면 짧은 이메일을 보내주시면 감사하겠습니다. 그리고 에디션 출처를 밝혀주세요.",
+    "noticeEditionLineFallback": "에디션 베빙크",
+    "writeToMe": "메일 보내기",
+    "emptyTitle": "라이브러리를 준비 중입니다.",
+    "emptyBody": "에디션은 준비되는 대로 여기에 표시됩니다. 다시 확인하거나 아래로 메일을 보내주세요.",
+    "editionsCount": "에디션 {count}개",
+    "sort": "정렬: {label}",
+    "period": "시대",
+    "download": "다운로드",
+    "feature": "추천 에디션",
+    "featuredHeader": "추천 에디션",
     "editionNumber": "No. {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "카탈로그",
+      "period": "시대",
+      "pages": "페이지",
+      "edition": "에디션"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "downloadPdf": "PDF 다운로드",
+    "noPdfYet": "아직 PDF 없음",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "pagesShort": "{count}쪽",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "곧 제공",
+    "libraryHeading": "<em>라이브러리</em>",
+    "showing": "총 {total}개 중 {shown}개 표시",
+    "emptyFilter": "이 카테고리에 아직 항목이 없습니다 — 다른 필터를 시도해 보세요."
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "소개",
+    "emptyBody": "이 페이지는 아직 스튜디오에서 설정되지 않았습니다.",
+    "emptyHint": "<code>/admin → 소개 페이지</code>를 열어 콘텐츠를 추가하세요.",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "궤적",
+    "trajectoryHeading": "짧은 <em>연대기</em> — 제가 여기까지 온 과정.",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "연주곡",
+    "repertoireHeading": "제가 계속 <em>다시 연주하는</em> 레퍼토리."
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "개인정보처리방침",
+    "emptyBody": "이 페이지는 아직 스튜디오에서 설정되지 않았습니다.",
+    "emptyHint": "<code>/admin → 개인정보처리방침 페이지</code>를 열어 콘텐츠를 추가하세요.",
+    "lastUpdated": "마지막 업데이트: {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "외부 링크",
+    "emptyTitle": "외부 링크",
+    "emptyBody": "이 페이지는 아직 스튜디오에서 설정되지 않았습니다.",
+    "emptyHint": "<code>/admin → 외부 링크 페이지</code>를 열어 링크를 추가하세요.",
+    "noLinks": "아직 링크가 없습니다."
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "저널",
+    "previousEntry": "← 이전 글",
+    "nextEntry": "다음 글 →",
+    "endOfJournal": "— 저널 끝 —",
+    "minRead": "읽는 데 {count}분",
     "categories": {
-      "travelogue": "Travelogue",
-      "workshop": "Workshop",
-      "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "travelogue": "여행기",
+      "workshop": "워크숍",
+      "memorial": "추모",
+      "home-organ": "가정용 오르간",
+      "biography": "전기",
+      "news": "소식",
+      "collection": "컬렉션",
+      "other": "현장 기록"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "모든 오르간",
+    "fieldNote": "현장 기록",
+    "previousVisit": "← 이전 방문",
+    "nextVisit": "다음 방문 →",
+    "endOfJournal": "— 저널 끝 —",
+    "minRead": "읽는 데 {count}분"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -6,7 +6,7 @@
     "taglineFallback": "Organist",
     "items": {
       "organs": "Orgels",
-      "scores": "Bladmuziek",
+      "scores": "Partituren",
       "about": "Over mij",
       "elsewhere": "Elders"
     }
@@ -23,27 +23,27 @@
     "home": "Home",
     "organs": "Orgels",
     "journal": "Journaal",
-    "scores": "Bladmuziek",
+    "scores": "Partituren",
     "about": "Over",
     "elsewhere": "Elders",
     "privacy": "Privacy"
   },
   "LanguagePicker": {
     "label": "Taal",
-    "switchTo": "Overschakelen naar {language}"
+    "switchTo": "Schakel over naar {language}"
   },
   "Metadata": {
     "journal": {
       "title": "Journaal",
-      "description": "Essays, fragmenten, onaffe gedachten — gepubliceerd als er iets te melden valt."
+      "description": "Essays, fragmenten, half-afgemaakte gedachten — gepubliceerd wanneer er iets zinnigs te zeggen valt."
     },
     "organs": {
       "title": "Orgels",
-      "description": "Veldnotities van bezochte orgels in Nederland en daarbuiten."
+      "description": "Veldnotities van orgels bezocht in Nederland en daarbuiten."
     },
     "scores": {
-      "title": "Bladmuziek",
-      "description": "Werkedities van orgelmuziek, voorbereid door Bert Webbink — vingerzettingen, registraties, gratis te downloaden voor niet-commerciële studie."
+      "title": "Partituren",
+      "description": "Werkedities van orgelpartituren voorbereid door Bert Webbink — vingerzettingen, registraties, gratis te downloaden voor niet-commerciële studie."
     },
     "about": {
       "title": "Over mij",
@@ -51,7 +51,7 @@
     },
     "elsewhere": {
       "title": "Elders",
-      "description": "Verzamelde links — koren, kerken, orgelbronnen."
+      "description": "Gecureerde links — koren, kerken, orgelbronnen."
     },
     "privacy": {
       "title": "Privacy",
@@ -66,7 +66,7 @@
     "kickerLeftFallback": "Veldnotities",
     "kickerRightFallback": "Vanaf de orgelgalerij",
     "headingFallback": "Bezoeken aan {{oude orgels}}",
-    "taglineFallback": "Opnames, foto's en registers, zaterdag voor zaterdag verzameld in Nederland en daarbuiten.",
+    "taglineFallback": "Opnames, foto's en registers van telkens één zaterdag, verzameld in Nederland en daarbuiten.",
     "cornerLeftSubFallback": "Een veldjournaal",
     "cornerRightSubFallback": "De lage landen",
     "stats": "Sinds {firstYear} · {totalCount} orgels"
@@ -75,10 +75,10 @@
     "kickerLeftFallback": "Geschriften",
     "kickerRightFallback": "Een veldjournaal",
     "headingFallback": "Het {{Journaal}}",
-    "taglineFallback": "Essays, fragmenten, onaffe gedachten — gepubliceerd als er iets te melden valt, meestal nadat een orgelbank me van gedachten heeft doen veranderen.",
+    "taglineFallback": "Essays, fragmenten, half-afgemaakte gedachten — gepubliceerd wanneer er iets zinnigs te zeggen valt, meestal nadat een bankje mijn mening over iets heeft veranderd.",
     "cornerLeftSubFallback": "Notities tussen bezoeken",
     "cornerRightSubFallback": "De lage landen",
-    "stats": "Sinds {firstYear} · {totalCount} artikelen"
+    "stats": "Sinds {firstYear} · {totalCount} bijdragen"
   },
   "OrgansArchive": {
     "title": "Het archief",
@@ -100,45 +100,45 @@
     "filter": "Filter",
     "all": "Alles",
     "categories": {
-      "travelogue": "Reizen",
+      "travelogue": "Reis",
       "workshop": "Workshop",
-      "memorial": "In memoriam",
+      "memorial": "Herdenking",
       "home-organ": "Huisorgel",
       "biography": "Biografie",
       "news": "Nieuws",
-      "collection": "Verzameling",
+      "collection": "Collectie",
       "other": "Overig"
     },
     "categoryKinds": {
       "travelogue": "reisverslag",
       "workshop": "bezoek",
-      "memorial": "in memoriam",
+      "memorial": "herdenking",
       "home-organ": "huisorgel",
       "biography": "biografie",
       "news": "nieuws",
-      "collection": "verzameling",
+      "collection": "collectie",
       "other": "notitie"
     },
-    "entriesCount": "{count, plural, one {# artikel} other {# artikelen}}",
+    "entriesCount": "{count, plural, one {# bijdrage} other {# bijdragen}}",
     "emptyCategory": "Nog niets in deze categorie.",
     "pagination": {
       "newer": "← Nieuwer",
       "older": "Ouder →",
       "pageOf": "Pagina {current} van {total}"
     },
-    "hasAudio": "Bevat audio",
-    "readEntry": "Lees artikel",
+    "hasAudio": "Met audio",
+    "readEntry": "Lees bijdrage",
     "minRead": "{count, plural, one {# min. leestijd} other {# min. leestijd}}"
   },
   "Specs": {
-    "specification": "Dispositie",
+    "specification": "Specificatie",
     "manuals": "Manualen",
     "stops": "Registers",
     "pitch": "Toonhoogte",
-    "temperament": "Temperament",
+    "temperament": "Stemming",
     "action": "Tractuur",
     "couplings": "Koppelingen",
-    "accessories": "Speelhulpen",
+    "accessories": "Accessoires",
     "built": "Gebouwd {year}",
     "restored": "Gerestaureerd {year}"
   },
@@ -157,17 +157,17 @@
       "edition": "Editie №"
     },
     "headerKickerFallback": "Een kleine bibliotheek",
-    "headerHeadingFallback": "Edities, vingerzettingen, {{werkkopieën}}.",
-    "headerTaglineFallback": "Werkedities die ik voor eigen gebruik heb voorbereid — de meeste voor specifieke instrumenten die in de veldnotities worden bezocht. Vingerzettingen en registraties zijn suggesties, geen voorschriften. Alle bladmuziek is gratis te downloaden voor niet-commerciële studie.",
-    "noticeBodyFallback": "Deze bladmuziek wordt gedeeld voor persoonlijke studie en kerkelijk gebruik. Als u een stuk wilt uitvoeren of opnemen, wordt een korte e-mail op prijs gesteld — en vermeld alstublieft de editie.",
+    "headerHeadingFallback": "Edities, vingerzettingen, {{werkpartituren}}.",
+    "headerTaglineFallback": "Werkedities die ik voor eigen gebruik heb voorbereid — de meeste voor specifieke instrumenten die in de veldnotities zijn bezocht. Vingerzettingen en registraties zijn suggesties, geen voorschriften. Alle partituren zijn gratis te downloaden voor niet-commerciële studie.",
+    "noticeBodyFallback": "Deze partituren worden gedeeld voor persoonlijke studie en kerkelijk gebruik. Als u er een wilt uitvoeren of opnemen, wordt een korte e-mail op prijs gesteld — en vermeld alstublieft de editie.",
     "noticeEditionLineFallback": "Editie Webbink",
     "writeToMe": "Schrijf me",
-    "emptyTitle": "De bibliotheek wordt nog opgezet.",
-    "emptyBody": "Edities zullen hier verschijnen zodra ik ze voorbereid heb. Kom later terug, of schrijf me hieronder.",
+    "emptyTitle": "De bibliotheek wordt momenteel ingericht.",
+    "emptyBody": "Edities verschijnen hier zodra ik ze voorbereid. Kom terug, of schrijf me hieronder.",
     "editionsCount": "{count, plural, one {# editie} other {# edities}}",
-    "sort": "Sorteer: {label}",
+    "sort": "Sorteren: {label}",
     "period": "Periode",
-    "download": "Download",
+    "download": "Downloaden",
     "feature": "Uitgelichte editie",
     "featuredHeader": "Uitgelichte editie",
     "editionNumber": "Nr. {number}",
@@ -180,7 +180,7 @@
     "downloadPdf": "Download PDF",
     "noPdfYet": "Nog geen PDF",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pag.",
+    "pagesShort": "{count} pp",
     "pdfTag": "PDF",
     "comingSoon": "binnenkort",
     "libraryHeading": "De <em>bibliotheek</em>",
@@ -190,31 +190,31 @@
   "About": {
     "emptyTitle": "Over mij",
     "emptyBody": "Deze pagina is nog niet ingesteld in de Studio.",
-    "emptyHint": "Open <code>/admin → Over-pagina</code> om de inhoud toe te voegen.",
+    "emptyHint": "Open <code>/admin → Over mij pagina</code> om de inhoud toe te voegen.",
     "trajectoryNum": "01",
     "trajectoryLabel": "Traject",
-    "trajectoryHeading": "Een korte <em>chronologie</em> — hoe ik hier ben gekomen.",
+    "trajectoryHeading": "Een korte <em>chronologie</em> — hoe ik hier terechtkwam.",
     "repertoireNum": "02",
     "repertoireLabel": "Wat ik speel",
-    "repertoireHeading": "Repertoire waar ik steeds <em>naar terugkeer</em>."
+    "repertoireHeading": "Repertoire waar ik steeds weer <em>naar terugkeer</em>."
   },
   "Privacy": {
     "emptyTitle": "Privacy",
     "emptyBody": "Deze pagina is nog niet ingesteld in de Studio.",
-    "emptyHint": "Open <code>/admin → Privacy-pagina</code> om de inhoud toe te voegen.",
-    "lastUpdated": "Laatst bijgewerkt op {date}"
+    "emptyHint": "Open <code>/admin → Privacy pagina</code> om de inhoud toe te voegen.",
+    "lastUpdated": "Laatst bijgewerkt {date}"
   },
   "Elsewhere": {
     "title": "Elders",
     "emptyTitle": "Elders",
     "emptyBody": "Deze pagina is nog niet ingesteld in de Studio.",
-    "emptyHint": "Open <code>/admin → Elders-pagina</code> om links toe te voegen.",
+    "emptyHint": "Open <code>/admin → Elders pagina</code> om links toe te voegen.",
     "noLinks": "Nog geen links."
   },
   "JournalArticle": {
     "breadcrumbHome": "Het journaal",
-    "previousEntry": "← Vorig artikel",
-    "nextEntry": "Volgend artikel →",
+    "previousEntry": "← Vorige bijdrage",
+    "nextEntry": "Volgende bijdrage →",
     "endOfJournal": "— einde van het journaal —",
     "minRead": "{count, plural, one {# min. leestijd} other {# min. leestijd}}",
     "categories": {
@@ -224,7 +224,7 @@
       "home-organ": "Huisorgel",
       "biography": "Biografie",
       "news": "Nieuws",
-      "collection": "Verzameling",
+      "collection": "Collectie",
       "other": "Veldnotitie"
     }
   },

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
+    "openMenu": "Menu openen",
+    "closeMenu": "Menu sluiten",
     "wordmarkFallback": "Bert Webbink",
     "taglineFallback": "Organist",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "Orgels",
+      "scores": "Bladmuziek",
+      "about": "Over mij",
+      "elsewhere": "Elders"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
       "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
+      "elsewhere": "Elders",
       "contact": "Contact"
     }
   },
   "Crumbs": {
     "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
+    "organs": "Orgels",
+    "journal": "Journaal",
+    "scores": "Bladmuziek",
+    "about": "Over",
+    "elsewhere": "Elders",
     "privacy": "Privacy"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "Taal",
+    "switchTo": "Overschakelen naar {language}"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "Journaal",
+      "description": "Essays, fragmenten, onaffe gedachten — gepubliceerd als er iets te melden valt."
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "Orgels",
+      "description": "Veldnotities van bezochte orgels in Nederland en daarbuiten."
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "Bladmuziek",
+      "description": "Werkedities van orgelmuziek, voorbereid door Bert Webbink — vingerzettingen, registraties, gratis te downloaden voor niet-commerciële studie."
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "Over mij",
+      "description": "Bert Webbink — organist, docent, stille bezoeker van oude gebouwen."
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "Elders",
+      "description": "Verzamelde links — koren, kerken, orgelbronnen."
     },
     "privacy": {
       "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "description": "Een korte, duidelijke notitie over wat er wordt gelogd wanneer u deze site bezoekt."
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "In aanbouw",
+    "subtitle": "Kom snel terug."
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "Veldnotities",
+    "kickerRightFallback": "Vanaf de orgelgalerij",
+    "headingFallback": "Bezoeken aan {{oude orgels}}",
+    "taglineFallback": "Opnames, foto's en registers, zaterdag voor zaterdag verzameld in Nederland en daarbuiten.",
+    "cornerLeftSubFallback": "Een veldjournaal",
+    "cornerRightSubFallback": "De lage landen",
+    "stats": "Sinds {firstYear} · {totalCount} orgels"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "Geschriften",
+    "kickerRightFallback": "Een veldjournaal",
+    "headingFallback": "Het {{Journaal}}",
+    "taglineFallback": "Essays, fragmenten, onaffe gedachten — gepubliceerd als er iets te melden valt, meestal nadat een orgelbank me van gedachten heeft doen veranderen.",
+    "cornerLeftSubFallback": "Notities tussen bezoeken",
+    "cornerRightSubFallback": "De lage landen",
+    "stats": "Sinds {firstYear} · {totalCount} artikelen"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "Het archief",
+    "filteredTitle": "Bezoeken in <city>{city}</city>",
+    "byCity": "Per stad",
+    "browseAll": "Bekijk alles →",
+    "shownOfTotal": "{shown} van {total}",
+    "clearFilter": "filter wissen ✕",
+    "loading": "Laden…",
+    "endOfArchive": "— einde van het archief —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
+    "readMore": "Lees meer",
+    "audioFragment": "Audiofragment",
     "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "placeholderLabel": "orgelfoto"
   },
   "JournalList": {
     "filter": "Filter",
-    "all": "All",
+    "all": "Alles",
     "categories": {
-      "travelogue": "Travel",
+      "travelogue": "Reizen",
       "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "memorial": "In memoriam",
+      "home-organ": "Huisorgel",
+      "biography": "Biografie",
+      "news": "Nieuws",
+      "collection": "Verzameling",
+      "other": "Overig"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "reisverslag",
+      "workshop": "bezoek",
+      "memorial": "in memoriam",
+      "home-organ": "huisorgel",
+      "biography": "biografie",
+      "news": "nieuws",
+      "collection": "verzameling",
+      "other": "notitie"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count, plural, one {# artikel} other {# artikelen}}",
+    "emptyCategory": "Nog niets in deze categorie.",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← Nieuwer",
+      "older": "Ouder →",
+      "pageOf": "Pagina {current} van {total}"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "Bevat audio",
+    "readEntry": "Lees artikel",
+    "minRead": "{count, plural, one {# min. leestijd} other {# min. leestijd}}"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
+    "specification": "Dispositie",
+    "manuals": "Manualen",
+    "stops": "Registers",
+    "pitch": "Toonhoogte",
     "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "action": "Tractuur",
+    "couplings": "Koppelingen",
+    "accessories": "Speelhulpen",
+    "built": "Gebouwd {year}",
+    "restored": "Gerestaureerd {year}"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
+      "all": "Alles",
+      "baroque": "Barok",
+      "dutch": "Nederlandse School",
+      "romantic": "Romantiek",
       "modern": "Modern",
-      "arrangement": "Arrangements"
+      "arrangement": "Arrangementen"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "Componist",
+      "year": "Jaar",
+      "edition": "Editie №"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
+    "headerKickerFallback": "Een kleine bibliotheek",
+    "headerHeadingFallback": "Edities, vingerzettingen, {{werkkopieën}}.",
+    "headerTaglineFallback": "Werkedities die ik voor eigen gebruik heb voorbereid — de meeste voor specifieke instrumenten die in de veldnotities worden bezocht. Vingerzettingen en registraties zijn suggesties, geen voorschriften. Alle bladmuziek is gratis te downloaden voor niet-commerciële studie.",
+    "noticeBodyFallback": "Deze bladmuziek wordt gedeeld voor persoonlijke studie en kerkelijk gebruik. Als u een stuk wilt uitvoeren of opnemen, wordt een korte e-mail op prijs gesteld — en vermeld alstublieft de editie.",
+    "noticeEditionLineFallback": "Editie Webbink",
+    "writeToMe": "Schrijf me",
+    "emptyTitle": "De bibliotheek wordt nog opgezet.",
+    "emptyBody": "Edities zullen hier verschijnen zodra ik ze voorbereid heb. Kom later terug, of schrijf me hieronder.",
+    "editionsCount": "{count, plural, one {# editie} other {# edities}}",
+    "sort": "Sorteer: {label}",
+    "period": "Periode",
     "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "feature": "Uitgelichte editie",
+    "featuredHeader": "Uitgelichte editie",
+    "editionNumber": "Nr. {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "Catalogus",
+      "period": "Periode",
+      "pages": "Pagina's",
+      "edition": "Editie"
     },
     "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "noPdfYet": "Nog geen PDF",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "pagesShort": "{count} pag.",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "binnenkort",
+    "libraryHeading": "De <em>bibliotheek</em>",
+    "showing": "{shown} van {total} getoond",
+    "emptyFilter": "Nog niets in deze categorie — probeer een ander filter."
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "Over mij",
+    "emptyBody": "Deze pagina is nog niet ingesteld in de Studio.",
+    "emptyHint": "Open <code>/admin → Over-pagina</code> om de inhoud toe te voegen.",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "Traject",
+    "trajectoryHeading": "Een korte <em>chronologie</em> — hoe ik hier ben gekomen.",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "Wat ik speel",
+    "repertoireHeading": "Repertoire waar ik steeds <em>naar terugkeer</em>."
   },
   "Privacy": {
     "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyBody": "Deze pagina is nog niet ingesteld in de Studio.",
+    "emptyHint": "Open <code>/admin → Privacy-pagina</code> om de inhoud toe te voegen.",
+    "lastUpdated": "Laatst bijgewerkt op {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "Elders",
+    "emptyTitle": "Elders",
+    "emptyBody": "Deze pagina is nog niet ingesteld in de Studio.",
+    "emptyHint": "Open <code>/admin → Elders-pagina</code> om links toe te voegen.",
+    "noLinks": "Nog geen links."
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "Het journaal",
+    "previousEntry": "← Vorig artikel",
+    "nextEntry": "Volgend artikel →",
+    "endOfJournal": "— einde van het journaal —",
+    "minRead": "{count, plural, one {# min. leestijd} other {# min. leestijd}}",
     "categories": {
-      "travelogue": "Travelogue",
+      "travelogue": "Reisverslag",
       "workshop": "Workshop",
       "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "home-organ": "Huisorgel",
+      "biography": "Biografie",
+      "news": "Nieuws",
+      "collection": "Verzameling",
+      "other": "Veldnotitie"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "Alle orgels",
+    "fieldNote": "Veldnotitie",
+    "previousVisit": "← Vorig bezoek",
+    "nextVisit": "Volgend bezoek →",
+    "endOfJournal": "— einde van het journaal —",
+    "minRead": "{count, plural, one {# min. leestijd} other {# min. leestijd}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
+    "openMenu": "Abrir menu",
+    "closeMenu": "Fechar menu",
     "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "taglineFallback": "Organista",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "Órgãos",
+      "scores": "Partituras",
+      "about": "Sobre mim",
+      "elsewhere": "Outros locais"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "privacy": "Privacidade",
+      "elsewhere": "Outros locais",
+      "contact": "Contacto"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "home": "Início",
+    "organs": "Órgãos",
+    "journal": "Diário",
+    "scores": "Partituras",
+    "about": "Sobre",
+    "elsewhere": "Outros locais",
+    "privacy": "Privacidade"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "Idioma",
+    "switchTo": "Mudar para {language}"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "Diário",
+      "description": "Ensaios, fragmentos, pensamentos inacabados — publicados quando há algo que valha a pena dizer."
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "Órgãos",
+      "description": "Notas de campo de órgãos visitados nos Países Baixos e além."
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "Partituras",
+      "description": "Edições de trabalho de partituras para órgão preparadas por Bert Webbink — dedilhados, registos, disponíveis para download gratuito para estudo não comercial."
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "Sobre mim",
+      "description": "Bert Webbink — organista, professor, visitante silencioso de edifícios antigos."
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "Outros locais",
+      "description": "Links selecionados — coros, igrejas, recursos para órgão."
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "Privacidade",
+      "description": "Uma nota curta e em linguagem simples sobre o que é registado quando visita este site."
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "Em construção",
+    "subtitle": "Volte em breve."
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "Notas de campo",
+    "kickerRightFallback": "Do coro do órgão",
+    "headingFallback": "Visitas a {{órgãos antigos}}",
+    "taglineFallback": "Gravações, fotografias e registos de um sábado de cada vez, recolhidos nos Países Baixos e além.",
+    "cornerLeftSubFallback": "Um diário de campo",
+    "cornerRightSubFallback": "Os Países Baixos",
+    "stats": "Desde {firstYear} · {totalCount} órgãos"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "Escritos",
+    "kickerRightFallback": "Um diário de campo",
+    "headingFallback": "O {{Diário}}",
+    "taglineFallback": "Ensaios, fragmentos, pensamentos inacabados — publicados quando há algo que valha a pena dizer, geralmente depois de um banco de órgão me ter feito mudar de ideias sobre algo.",
+    "cornerLeftSubFallback": "Notas entre visitas",
+    "cornerRightSubFallback": "Os Países Baixos",
+    "stats": "Desde {firstYear} · {totalCount} entradas"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "O arquivo",
+    "filteredTitle": "Visitas em <city>{city}</city>",
+    "byCity": "Por cidade",
+    "browseAll": "Ver todos →",
+    "shownOfTotal": "{shown} de {total}",
+    "clearFilter": "limpar filtro ✕",
+    "loading": "A carregar…",
+    "endOfArchive": "— fim do arquivo —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
-    "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "readMore": "Ler mais",
+    "audioFragment": "Fragmento de áudio",
+    "video": "Vídeo",
+    "placeholderLabel": "fotografia de órgão"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "Filtrar",
+    "all": "Todos",
     "categories": {
-      "travelogue": "Travel",
+      "travelogue": "Viagem",
       "workshop": "Workshop",
       "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "home-organ": "Órgão de casa",
+      "biography": "Biografia",
+      "news": "Notícias",
+      "collection": "Coleção",
+      "other": "Outro"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
+      "travelogue": "diário de viagem",
+      "workshop": "visita",
       "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "home-organ": "órgão de casa",
+      "biography": "biografia",
+      "news": "notícia",
+      "collection": "coleção",
+      "other": "nota"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count, plural, one {# entrada} other {# entradas}}",
+    "emptyCategory": "Ainda nada nesta categoria.",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← Mais recentes",
+      "older": "Mais antigos →",
+      "pageOf": "Página {current} de {total}"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "Tem áudio",
+    "readEntry": "Ler entrada",
+    "minRead": "{count, plural, one {# min de leitura} other {# min de leitura}}"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "Especificação",
+    "manuals": "Manuais",
+    "stops": "Registos",
+    "pitch": "Afinação",
+    "temperament": "Temperamento",
+    "action": "Tração",
+    "couplings": "Acoplamentos",
+    "accessories": "Acessórios",
+    "built": "Construído em {year}",
+    "restored": "Restaurado em {year}"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "Todos",
+      "baroque": "Barroco",
+      "dutch": "Escola Holandesa",
+      "romantic": "Romântico",
+      "modern": "Moderno",
+      "arrangement": "Arranjos"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "Compositor",
+      "year": "Ano",
+      "edition": "Edição n.º"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
+    "headerKickerFallback": "Uma pequena biblioteca",
+    "headerHeadingFallback": "Edições, dedilhados, {{partituras de trabalho}}.",
+    "headerTaglineFallback": "Edições de trabalho que preparei para uso próprio — a maioria para instrumentos específicos visitados nas notas de campo. Os dedilhados e registos são sugestões, não prescrições. Todas as partituras estão disponíveis para download gratuito para estudo não comercial.",
+    "noticeBodyFallback": "Estas partituras são partilhadas para estudo pessoal e uso na igreja. Se desejar executar ou gravar uma, agradece-se um breve e-mail — e, por favor, dê crédito à edição.",
+    "noticeEditionLineFallback": "Edição Webbink",
+    "writeToMe": "Escreva-me",
+    "emptyTitle": "A biblioteca está a ser criada.",
+    "emptyBody": "As edições aparecerão aqui à medida que as preparo. Volte mais tarde ou escreva-me abaixo.",
+    "editionsCount": "{count, plural, one {# edição} other {# edições}}",
+    "sort": "Ordenar: {label}",
+    "period": "Período",
     "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "feature": "Edição em destaque",
+    "featuredHeader": "Edição em destaque",
+    "editionNumber": "N.º {number}",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "Catálogo",
+      "period": "Período",
+      "pages": "Páginas",
+      "edition": "Edição"
     },
     "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "noPdfYet": "Ainda sem PDF",
     "editionLineSuffix": "· {year}",
     "pagesShort": "{count} pp",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "em breve",
+    "libraryHeading": "A <em>biblioteca</em>",
+    "showing": "A mostrar {shown} de {total}",
+    "emptyFilter": "Ainda nada nesta categoria — experimente outro filtro."
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "Sobre mim",
+    "emptyBody": "Esta página ainda não foi configurada no Studio.",
+    "emptyHint": "Abra <code>/admin → Página Sobre</code> para adicionar o conteúdo.",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "Trajetória",
+    "trajectoryHeading": "Uma breve <em>cronologia</em> — como cheguei aqui.",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "O que toco",
+    "repertoireHeading": "Repertório ao qual <em>continuo a voltar</em>."
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "Privacidade",
+    "emptyBody": "Esta página ainda não foi configurada no Studio.",
+    "emptyHint": "Abra <code>/admin → Página de Privacidade</code> para adicionar o conteúdo.",
+    "lastUpdated": "Última atualização: {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "Outros locais",
+    "emptyTitle": "Outros locais",
+    "emptyBody": "Esta página ainda não foi configurada no Studio.",
+    "emptyHint": "Abra <code>/admin → Página Outros locais</code> para adicionar links.",
+    "noLinks": "Ainda sem links."
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "O diário",
+    "previousEntry": "← Entrada anterior",
+    "nextEntry": "Próxima entrada →",
+    "endOfJournal": "— fim do diário —",
+    "minRead": "{count, plural, one {# min de leitura} other {# min de leitura}}",
     "categories": {
-      "travelogue": "Travelogue",
+      "travelogue": "Diário de viagem",
       "workshop": "Workshop",
       "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "home-organ": "Órgão de casa",
+      "biography": "Biografia",
+      "news": "Notícias",
+      "collection": "Coleção",
+      "other": "Nota de campo"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "Todos os órgãos",
+    "fieldNote": "Nota de campo",
+    "previousVisit": "← Visita anterior",
+    "nextVisit": "Próxima visita →",
+    "endOfJournal": "— fim do diário —",
+    "minRead": "{count, plural, one {# min de leitura} other {# min de leitura}}"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -16,7 +16,7 @@
     "links": {
       "privacy": "Privacidade",
       "elsewhere": "Outros locais",
-      "contact": "Contacto"
+      "contact": "Contato"
     }
   },
   "Crumbs": {
@@ -43,7 +43,7 @@
     },
     "scores": {
       "title": "Partituras",
-      "description": "Edições de trabalho de partituras para órgão preparadas por Bert Webbink — dedilhados, registos, disponíveis para download gratuito para estudo não comercial."
+      "description": "Edições de trabalho de partituras de órgão preparadas por Bert Webbink — digitações, registros, download gratuito para estudo não comercial."
     },
     "about": {
       "title": "Sobre mim",
@@ -51,11 +51,11 @@
     },
     "elsewhere": {
       "title": "Outros locais",
-      "description": "Links selecionados — coros, igrejas, recursos para órgão."
+      "description": "Links selecionados — coros, igrejas, recursos de órgão."
     },
     "privacy": {
       "title": "Privacidade",
-      "description": "Uma nota curta e em linguagem simples sobre o que é registado quando visita este site."
+      "description": "Uma nota curta e em linguagem simples sobre o que é registrado quando você visita este site."
     }
   },
   "UnderConstruction": {
@@ -66,7 +66,7 @@
     "kickerLeftFallback": "Notas de campo",
     "kickerRightFallback": "Do coro do órgão",
     "headingFallback": "Visitas a {{órgãos antigos}}",
-    "taglineFallback": "Gravações, fotografias e registos de um sábado de cada vez, recolhidos nos Países Baixos e além.",
+    "taglineFallback": "Gravações, fotografias e registros de um sábado de cada vez, reunidos nos Países Baixos e além.",
     "cornerLeftSubFallback": "Um diário de campo",
     "cornerRightSubFallback": "Os Países Baixos",
     "stats": "Desde {firstYear} · {totalCount} órgãos"
@@ -75,7 +75,7 @@
     "kickerLeftFallback": "Escritos",
     "kickerRightFallback": "Um diário de campo",
     "headingFallback": "O {{Diário}}",
-    "taglineFallback": "Ensaios, fragmentos, pensamentos inacabados — publicados quando há algo que valha a pena dizer, geralmente depois de um banco de órgão me ter feito mudar de ideias sobre algo.",
+    "taglineFallback": "Ensaios, fragmentos, pensamentos inacabados — publicados quando há algo que valha a pena dizer, geralmente depois que um banco me fez mudar de ideia sobre algo.",
     "cornerLeftSubFallback": "Notas entre visitas",
     "cornerRightSubFallback": "Os Países Baixos",
     "stats": "Desde {firstYear} · {totalCount} entradas"
@@ -87,7 +87,7 @@
     "browseAll": "Ver todos →",
     "shownOfTotal": "{shown} de {total}",
     "clearFilter": "limpar filtro ✕",
-    "loading": "A carregar…",
+    "loading": "Carregando…",
     "endOfArchive": "— fim do arquivo —"
   },
   "OrganCard": {
@@ -103,7 +103,7 @@
       "travelogue": "Viagem",
       "workshop": "Workshop",
       "memorial": "Memorial",
-      "home-organ": "Órgão de casa",
+      "home-organ": "Órgão doméstico",
       "biography": "Biografia",
       "news": "Notícias",
       "collection": "Coleção",
@@ -113,14 +113,14 @@
       "travelogue": "diário de viagem",
       "workshop": "visita",
       "memorial": "memorial",
-      "home-organ": "órgão de casa",
+      "home-organ": "órgão doméstico",
       "biography": "biografia",
-      "news": "notícia",
+      "news": "notícias",
       "collection": "coleção",
       "other": "nota"
     },
     "entriesCount": "{count, plural, one {# entrada} other {# entradas}}",
-    "emptyCategory": "Ainda nada nesta categoria.",
+    "emptyCategory": "Nada nesta categoria ainda.",
     "pagination": {
       "newer": "← Mais recentes",
       "older": "Mais antigos →",
@@ -133,10 +133,10 @@
   "Specs": {
     "specification": "Especificação",
     "manuals": "Manuais",
-    "stops": "Registos",
+    "stops": "Registros",
     "pitch": "Afinação",
     "temperament": "Temperamento",
-    "action": "Tração",
+    "action": "Mecânica",
     "couplings": "Acoplamentos",
     "accessories": "Acessórios",
     "built": "Construído em {year}",
@@ -154,38 +154,38 @@
     "sortBy": {
       "composer": "Compositor",
       "year": "Ano",
-      "edition": "Edição n.º"
+      "edition": "Edição nº"
     },
     "headerKickerFallback": "Uma pequena biblioteca",
-    "headerHeadingFallback": "Edições, dedilhados, {{partituras de trabalho}}.",
-    "headerTaglineFallback": "Edições de trabalho que preparei para uso próprio — a maioria para instrumentos específicos visitados nas notas de campo. Os dedilhados e registos são sugestões, não prescrições. Todas as partituras estão disponíveis para download gratuito para estudo não comercial.",
-    "noticeBodyFallback": "Estas partituras são partilhadas para estudo pessoal e uso na igreja. Se desejar executar ou gravar uma, agradece-se um breve e-mail — e, por favor, dê crédito à edição.",
+    "headerHeadingFallback": "Edições, digitações, {{partituras de trabalho}}.",
+    "headerTaglineFallback": "Edições de trabalho que preparei para meu próprio uso — a maioria para instrumentos específicos visitados nas notas de campo. Digitações e registros são sugestões, não prescrições. Todas as partituras são gratuitas para download para estudo não comercial.",
+    "noticeBodyFallback": "Estas partituras são compartilhadas para estudo pessoal e uso em igrejas. Se desejar executar ou gravar uma, um breve e-mail é apreciado — e por favor, credite a edição.",
     "noticeEditionLineFallback": "Edição Webbink",
     "writeToMe": "Escreva-me",
-    "emptyTitle": "A biblioteca está a ser criada.",
-    "emptyBody": "As edições aparecerão aqui à medida que as preparo. Volte mais tarde ou escreva-me abaixo.",
+    "emptyTitle": "A biblioteca está sendo configurada.",
+    "emptyBody": "As edições aparecerão aqui à medida que as preparo. Volte mais tarde, ou escreva-me abaixo.",
     "editionsCount": "{count, plural, one {# edição} other {# edições}}",
     "sort": "Ordenar: {label}",
     "period": "Período",
-    "download": "Download",
+    "download": "Baixar",
     "feature": "Edição em destaque",
     "featuredHeader": "Edição em destaque",
-    "editionNumber": "N.º {number}",
+    "editionNumber": "Nº {number}",
     "meta": {
       "catalog": "Catálogo",
       "period": "Período",
       "pages": "Páginas",
       "edition": "Edição"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "Ainda sem PDF",
+    "downloadPdf": "Baixar PDF",
+    "noPdfYet": "Nenhum PDF ainda",
     "editionLineSuffix": "· {year}",
     "pagesShort": "{count} pp",
     "pdfTag": "PDF",
     "comingSoon": "em breve",
     "libraryHeading": "A <em>biblioteca</em>",
-    "showing": "A mostrar {shown} de {total}",
-    "emptyFilter": "Ainda nada nesta categoria — experimente outro filtro."
+    "showing": "Mostrando {shown} de {total}",
+    "emptyFilter": "Nada nesta categoria ainda — tente outro filtro."
   },
   "About": {
     "emptyTitle": "Sobre mim",
@@ -193,23 +193,23 @@
     "emptyHint": "Abra <code>/admin → Página Sobre</code> para adicionar o conteúdo.",
     "trajectoryNum": "01",
     "trajectoryLabel": "Trajetória",
-    "trajectoryHeading": "Uma breve <em>cronologia</em> — como cheguei aqui.",
+    "trajectoryHeading": "Uma curta <em>cronologia</em> — como cheguei aqui.",
     "repertoireNum": "02",
     "repertoireLabel": "O que toco",
-    "repertoireHeading": "Repertório ao qual <em>continuo a voltar</em>."
+    "repertoireHeading": "Repertório ao qual <em>sempre retorno</em>."
   },
   "Privacy": {
     "emptyTitle": "Privacidade",
     "emptyBody": "Esta página ainda não foi configurada no Studio.",
     "emptyHint": "Abra <code>/admin → Página de Privacidade</code> para adicionar o conteúdo.",
-    "lastUpdated": "Última atualização: {date}"
+    "lastUpdated": "Última atualização em {date}"
   },
   "Elsewhere": {
     "title": "Outros locais",
     "emptyTitle": "Outros locais",
     "emptyBody": "Esta página ainda não foi configurada no Studio.",
     "emptyHint": "Abra <code>/admin → Página Outros locais</code> para adicionar links.",
-    "noLinks": "Ainda sem links."
+    "noLinks": "Nenhum link ainda."
   },
   "JournalArticle": {
     "breadcrumbHome": "O diário",
@@ -221,7 +221,7 @@
       "travelogue": "Diário de viagem",
       "workshop": "Workshop",
       "memorial": "In memoriam",
-      "home-organ": "Órgão de casa",
+      "home-organ": "Órgão doméstico",
       "biography": "Biografia",
       "news": "Notícias",
       "collection": "Coleção",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -8,87 +8,87 @@
       "organs": "管风琴",
       "scores": "乐谱",
       "about": "关于我",
-      "elsewhere": "其他链接"
+      "elsewhere": "其他"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
-      "privacy": "隐私政策",
-      "elsewhere": "其他链接",
+      "privacy": "隐私",
+      "elsewhere": "其他",
       "contact": "联系方式"
     }
   },
   "Crumbs": {
-    "home": "主页",
+    "home": "首页",
     "organs": "管风琴",
     "journal": "日志",
     "scores": "乐谱",
     "about": "关于",
-    "elsewhere": "其他链接",
-    "privacy": "隐私政策"
+    "elsewhere": "其他",
+    "privacy": "隐私"
   },
   "LanguagePicker": {
     "label": "语言",
-    "switchTo": "切换至{language}"
+    "switchTo": "切换到{language}"
   },
   "Metadata": {
     "journal": {
       "title": "日志",
-      "description": "随笔、片段、未完成的想法——当有值得分享的内容时发布。"
+      "description": "随笔、片段、未完成的思考——在有值得一说的事情时发表。"
     },
     "organs": {
       "title": "管风琴",
-      "description": "探访荷兰及其他地区管风琴的田野笔记。"
+      "description": "来自荷兰及其他地区参观过的管风琴的现场笔记。"
     },
     "scores": {
       "title": "乐谱",
-      "description": "由 Bert Webbink 整理的管风琴乐谱工作版——包含指法、音栓配置，可免费下载用于非商业性学习。"
+      "description": "Bert Webbink 准备的管风琴乐谱工作版本——指法、音栓设置，可免费下载用于非商业学习。"
     },
     "about": {
       "title": "关于我",
-      "description": "Bert Webbink——管风琴师、教师、古老建筑的静谧访客。"
+      "description": "Bert Webbink — 管风琴师、教师、古建筑的安静访客。"
     },
     "elsewhere": {
-      "title": "其他链接",
+      "title": "其他",
       "description": "精选链接——合唱团、教堂、管风琴资源。"
     },
     "privacy": {
-      "title": "隐私政策",
-      "description": "关于您访问本网站时会记录哪些信息的简短、通俗说明。"
+      "title": "隐私",
+      "description": "关于您访问本网站时记录内容的简短、通俗易懂的说明。"
     }
   },
   "UnderConstruction": {
     "title": "正在建设中",
-    "subtitle": "敬请期待。"
+    "subtitle": "请稍后回来。"
   },
   "Hero": {
-    "kickerLeftFallback": "田野笔记",
-    "kickerRightFallback": "来自管风琴演奏台",
-    "headingFallback": "探访{{古老管风琴}}",
-    "taglineFallback": "在荷兰及其他地区，于每个周六收集的录音、照片和音栓配置。",
-    "cornerLeftSubFallback": "田野日志",
+    "kickerLeftFallback": "现场笔记",
+    "kickerRightFallback": "来自管风琴阁楼",
+    "headingFallback": "参观{{古老的管风琴}}",
+    "taglineFallback": "来自荷兰及其他地区，一次一个周六的录音、照片和音栓记录。",
+    "cornerLeftSubFallback": "现场日志",
     "cornerRightSubFallback": "低地国家",
-    "stats": "始于 {firstYear} 年 · {totalCount} 台管风琴"
+    "stats": "自 {firstYear} 年 · {totalCount} 架管风琴"
   },
   "JournalHero": {
-    "kickerLeftFallback": "文章",
-    "kickerRightFallback": "田野日志",
+    "kickerLeftFallback": "作品",
+    "kickerRightFallback": "现场日志",
     "headingFallback": "{{日志}}",
-    "taglineFallback": "随笔、片段、未完成的想法——当有值得分享的内容时发布，通常是在琴凳上的思考改变了我的想法之后。",
-    "cornerLeftSubFallback": "探访间隙的笔记",
+    "taglineFallback": "随笔、片段、未完成的思考——在有值得一说的事情时发表，通常是在某个长凳改变了我的想法之后。",
+    "cornerLeftSubFallback": "访问间隙的笔记",
     "cornerRightSubFallback": "低地国家",
-    "stats": "始于 {firstYear} 年 · {totalCount} 篇"
+    "stats": "自 {firstYear} 年 · {totalCount} 篇日志"
   },
   "OrgansArchive": {
-    "title": "档案馆",
-    "filteredTitle": "在<city>{city}</city>的探访",
+    "title": "档案",
+    "filteredTitle": "在 <city>{city}</city> 的访问",
     "byCity": "按城市",
     "browseAll": "浏览全部 →",
     "shownOfTotal": "{shown} / {total}",
     "clearFilter": "清除筛选 ✕",
     "loading": "加载中…",
-    "endOfArchive": "— 档案馆尽头 —"
+    "endOfArchive": "— 档案结束 —"
   },
   "OrganCard": {
     "readMore": "阅读更多",
@@ -110,8 +110,8 @@
       "other": "其他"
     },
     "categoryKinds": {
-      "travelogue": "旅行随笔",
-      "workshop": "探访",
+      "travelogue": "游记",
+      "workshop": "访问",
       "memorial": "纪念",
       "home-organ": "家用管风琴",
       "biography": "传记",
@@ -119,27 +119,27 @@
       "collection": "收藏",
       "other": "笔记"
     },
-    "entriesCount": "{count} 篇",
-    "emptyCategory": "此分类下暂无内容。",
+    "entriesCount": "{count} 篇日志",
+    "emptyCategory": "此类别暂无内容。",
     "pagination": {
-      "newer": "← 新篇",
-      "older": "旧篇 →",
+      "newer": "← 较新",
+      "older": "较旧 →",
       "pageOf": "第 {current} 页 / 共 {total} 页"
     },
-    "hasAudio": "含音频",
-    "readEntry": "阅读文章",
-    "minRead": "阅读需 {count} 分钟"
+    "hasAudio": "包含音频",
+    "readEntry": "阅读日志",
+    "minRead": "{count} 分钟阅读"
   },
   "Specs": {
     "specification": "规格",
-    "manuals": "手键盘",
+    "manuals": "键盘",
     "stops": "音栓",
     "pitch": "音高",
     "temperament": "音律",
-    "action": "音栓机",
+    "action": "传动装置",
     "couplings": "联键",
     "accessories": "附件",
-    "built": "建于 {year} 年",
+    "built": "建造于 {year} 年",
     "restored": "修复于 {year} 年"
   },
   "Scores": {
@@ -156,21 +156,21 @@
       "year": "年份",
       "edition": "版本号"
     },
-    "headerKickerFallback": "小型乐谱库",
+    "headerKickerFallback": "一个小图书馆",
     "headerHeadingFallback": "版本、指法、{{工作乐谱}}。",
-    "headerTaglineFallback": "我为自用而整理的工作版乐谱——多数是为田野笔记中探访过的特定乐器而准备。指法和音栓配置仅为建议，并非规定。所有乐谱均可免费下载用于非商业性学习。",
-    "noticeBodyFallback": "这些乐谱仅供个人学习和教堂使用。如欲公开演奏或录音，请发邮件告知，不胜感激——并请注明版本来源。",
+    "headerTaglineFallback": "我为自己使用而准备的工作版本——大部分是为现场笔记中访问过的特定乐器而作。指法和音栓设置是建议，而非规定。所有乐谱均可免费下载用于非商业学习。",
+    "noticeBodyFallback": "这些乐谱供个人学习和教堂使用。如果您想演奏或录制其中一首，请发送简短邮件告知——并请注明版本。",
     "noticeEditionLineFallback": "Webbink 版本",
-    "writeToMe": "联系我",
-    "emptyTitle": "乐谱库正在建立中。",
-    "emptyBody": "乐谱整理好后会在此处显示。请稍后回来查看，或通过下方方式联系我。",
+    "writeToMe": "写信给我",
+    "emptyTitle": "图书馆正在建设中。",
+    "emptyBody": "我准备好后，版本将在此处显示。请稍后查看，或在下方写信给我。",
     "editionsCount": "{count} 个版本",
-    "sort": "排序: {label}",
+    "sort": "排序：{label}",
     "period": "时期",
     "download": "下载",
-    "feature": "精选版本",
-    "featuredHeader": "精选版本",
-    "editionNumber": "第 {number} 号",
+    "feature": "特色版本",
+    "featuredHeader": "特色版本",
+    "editionNumber": "编号 {number}",
     "meta": {
       "catalog": "目录",
       "period": "时期",
@@ -183,58 +183,58 @@
     "pagesShort": "{count} 页",
     "pdfTag": "PDF",
     "comingSoon": "即将推出",
-    "libraryHeading": "<em>乐谱库</em>",
-    "showing": "显示 {shown} / {total}",
-    "emptyFilter": "此分类下暂无内容——请尝试其他筛选条件。"
+    "libraryHeading": "<em>图书馆</em>",
+    "showing": "显示 {shown} / 共 {total}",
+    "emptyFilter": "此类别暂无内容——请尝试其他筛选条件。"
   },
   "About": {
     "emptyTitle": "关于我",
-    "emptyBody": "此页面尚未在工作室中设置。",
-    "emptyHint": "打开 <code>/admin → 关于页面</code> 以添加内容。",
+    "emptyBody": "此页面尚未在 Studio 中设置。",
+    "emptyHint": "打开 <code>/admin → 关于页面</code> 添加内容。",
     "trajectoryNum": "01",
     "trajectoryLabel": "轨迹",
-    "trajectoryHeading": "简短的<em>年表</em>——我的历程。",
+    "trajectoryHeading": "简短的<em>年表</em>——我是如何走到这一步的。",
     "repertoireNum": "02",
-    "repertoireLabel": "我的演奏曲目",
-    "repertoireHeading": "我反复<em>回归</em>的曲目。"
+    "repertoireLabel": "我演奏的曲目",
+    "repertoireHeading": "我一直<em>反复演奏</em>的曲目。"
   },
   "Privacy": {
-    "emptyTitle": "隐私政策",
-    "emptyBody": "此页面尚未在工作室中设置。",
-    "emptyHint": "打开 <code>/admin → 隐私页面</code> 以添加内容。",
+    "emptyTitle": "隐私",
+    "emptyBody": "此页面尚未在 Studio 中设置。",
+    "emptyHint": "打开 <code>/admin → 隐私页面</code> 添加内容。",
     "lastUpdated": "最后更新于 {date}"
   },
   "Elsewhere": {
-    "title": "其他链接",
-    "emptyTitle": "其他链接",
-    "emptyBody": "此页面尚未在工作室中设置。",
-    "emptyHint": "打开 <code>/admin → 其他链接页面</code> 以添加链接。",
+    "title": "其他",
+    "emptyTitle": "其他",
+    "emptyBody": "此页面尚未在 Studio 中设置。",
+    "emptyHint": "打开 <code>/admin → 其他页面</code> 添加链接。",
     "noLinks": "暂无链接。"
   },
   "JournalArticle": {
     "breadcrumbHome": "日志",
     "previousEntry": "← 上一篇",
     "nextEntry": "下一篇 →",
-    "endOfJournal": "— 日志尽头 —",
-    "minRead": "阅读需 {count} 分钟",
+    "endOfJournal": "— 日志结束 —",
+    "minRead": "{count} 分钟阅读",
     "categories": {
-      "travelogue": "旅行随笔",
+      "travelogue": "游记",
       "workshop": "工作坊",
       "memorial": "纪念",
       "home-organ": "家用管风琴",
       "biography": "传记",
       "news": "新闻",
       "collection": "收藏",
-      "other": "田野笔记"
+      "other": "现场笔记"
     }
   },
   "OrganArticle": {
     "breadcrumbAll": "所有管风琴",
-    "fieldNote": "田野笔记",
-    "previousVisit": "← 上次探访",
-    "nextVisit": "下次探访 →",
-    "endOfJournal": "— 日志尽头 —",
-    "minRead": "阅读需 {count} 分钟"
+    "fieldNote": "现场笔记",
+    "previousVisit": "← 上一次访问",
+    "nextVisit": "下一次访问 →",
+    "endOfJournal": "— 日志结束 —",
+    "minRead": "{count} 分钟阅读"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -61,5 +61,182 @@
   "UnderConstruction": {
     "title": "Under construction",
     "subtitle": "Come back soon."
+  },
+  "Hero": {
+    "kickerLeftFallback": "Field notes",
+    "kickerRightFallback": "From the organ loft",
+    "headingFallback": "Visits to {{old organs}}",
+    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
+    "cornerLeftSubFallback": "A field journal",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} organs"
+  },
+  "JournalHero": {
+    "kickerLeftFallback": "Writings",
+    "kickerRightFallback": "A field journal",
+    "headingFallback": "The {{Journal}}",
+    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
+    "cornerLeftSubFallback": "Notes between visits",
+    "cornerRightSubFallback": "The low countries",
+    "stats": "Since {firstYear} · {totalCount} entries"
+  },
+  "OrgansArchive": {
+    "title": "The archive",
+    "filteredTitle": "Visits in <city>{city}</city>",
+    "byCity": "By city",
+    "browseAll": "Browse all  →",
+    "shownOfTotal": "{shown} of {total}",
+    "clearFilter": "clear filter ✕",
+    "loading": "Loading…",
+    "endOfArchive": "— end of the archive —"
+  },
+  "OrganCard": {
+    "readMore": "Read more",
+    "audioFragment": "Audio fragment",
+    "video": "Video",
+    "placeholderLabel": "organ photograph"
+  },
+  "JournalList": {
+    "filter": "Filter",
+    "all": "All",
+    "categories": {
+      "travelogue": "Travel",
+      "workshop": "Workshop",
+      "memorial": "Memorial",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Other"
+    },
+    "categoryKinds": {
+      "travelogue": "travelogue",
+      "workshop": "visit",
+      "memorial": "memorial",
+      "home-organ": "home organ",
+      "biography": "biography",
+      "news": "news",
+      "collection": "collection",
+      "other": "note"
+    },
+    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
+    "emptyCategory": "Nothing in this category yet.",
+    "pagination": {
+      "newer": "← Newer",
+      "older": "Older →",
+      "pageOf": "Page {current} of {total}"
+    },
+    "hasAudio": "Has audio",
+    "readEntry": "Read entry",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Specs": {
+    "specification": "Specification",
+    "manuals": "Manuals",
+    "stops": "Stops",
+    "pitch": "Pitch",
+    "temperament": "Temperament",
+    "action": "Action",
+    "couplings": "Couplings",
+    "accessories": "Accessories",
+    "built": "Built {year}",
+    "restored": "Restored {year}"
+  },
+  "Scores": {
+    "filters": {
+      "all": "All",
+      "baroque": "Baroque",
+      "dutch": "Dutch School",
+      "romantic": "Romantic",
+      "modern": "Modern",
+      "arrangement": "Arrangements"
+    },
+    "sortBy": {
+      "composer": "Composer",
+      "year": "Year",
+      "edition": "Edition №"
+    },
+    "headerKickerFallback": "A small library",
+    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
+    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
+    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
+    "noticeEditionLineFallback": "Edition Webbink",
+    "writeToMe": "Write to me",
+    "emptyTitle": "The library is just being set up.",
+    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
+    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
+    "sort": "Sort: {label}",
+    "period": "Period",
+    "download": "Download",
+    "feature": "Featured edition",
+    "featuredHeader": "Featured edition",
+    "editionNumber": "No. {number}",
+    "meta": {
+      "catalog": "Catalog",
+      "period": "Period",
+      "pages": "Pages",
+      "edition": "Edition"
+    },
+    "downloadPdf": "Download PDF",
+    "noPdfYet": "No PDF yet",
+    "editionLineSuffix": "· {year}",
+    "pagesShort": "{count} pp",
+    "pdfTag": "PDF",
+    "comingSoon": "soon",
+    "libraryHeading": "The <em>library</em>",
+    "showing": "Showing {shown} of {total}",
+    "emptyFilter": "Nothing in this category yet — try another filter."
+  },
+  "About": {
+    "emptyTitle": "About me",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "trajectoryNum": "01",
+    "trajectoryLabel": "Trajectory",
+    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "repertoireNum": "02",
+    "repertoireLabel": "What I play",
+    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+  },
+  "Privacy": {
+    "emptyTitle": "Privacy",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
+    "lastUpdated": "Last updated {date}"
+  },
+  "Elsewhere": {
+    "title": "Elsewhere",
+    "emptyTitle": "Elsewhere",
+    "emptyBody": "This page hasn't been set up in the Studio yet.",
+    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
+    "noLinks": "No links yet."
+  },
+  "JournalArticle": {
+    "breadcrumbHome": "The journal",
+    "previousEntry": "← Previous entry",
+    "nextEntry": "Next entry →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "categories": {
+      "travelogue": "Travelogue",
+      "workshop": "Workshop",
+      "memorial": "In memoriam",
+      "home-organ": "Home organ",
+      "biography": "Biography",
+      "news": "News",
+      "collection": "Collection",
+      "other": "Field note"
+    }
+  },
+  "OrganArticle": {
+    "breadcrumbAll": "All organs",
+    "fieldNote": "Field note",
+    "previousVisit": "← Previous visit",
+    "nextVisit": "Next visit →",
+    "endOfJournal": "— end of the journal —",
+    "minRead": "{count, plural, one {# min read} other {# min read}}"
+  },
+  "Placeholder": {
+    "label": "[ {fallback} ]"
   }
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,240 +1,240 @@
 {
   "Nav": {
-    "openMenu": "Open menu",
-    "closeMenu": "Close menu",
+    "openMenu": "打开菜单",
+    "closeMenu": "关闭菜单",
     "wordmarkFallback": "Bert Webbink",
-    "taglineFallback": "Organist",
+    "taglineFallback": "管风琴师",
     "items": {
-      "organs": "Organs",
-      "scores": "Scores",
-      "about": "About me",
-      "elsewhere": "Elsewhere"
+      "organs": "管风琴",
+      "scores": "乐谱",
+      "about": "关于我",
+      "elsewhere": "其他链接"
     }
   },
   "Footer": {
     "copyright": "© Bert Webbink, {year}",
     "links": {
-      "privacy": "Privacy",
-      "elsewhere": "Elsewhere",
-      "contact": "Contact"
+      "privacy": "隐私政策",
+      "elsewhere": "其他链接",
+      "contact": "联系方式"
     }
   },
   "Crumbs": {
-    "home": "Home",
-    "organs": "Organs",
-    "journal": "Journal",
-    "scores": "Scores",
-    "about": "About",
-    "elsewhere": "Elsewhere",
-    "privacy": "Privacy"
+    "home": "主页",
+    "organs": "管风琴",
+    "journal": "日志",
+    "scores": "乐谱",
+    "about": "关于",
+    "elsewhere": "其他链接",
+    "privacy": "隐私政策"
   },
   "LanguagePicker": {
-    "label": "Language",
-    "switchTo": "Switch to {language}"
+    "label": "语言",
+    "switchTo": "切换至{language}"
   },
   "Metadata": {
     "journal": {
-      "title": "Journal",
-      "description": "Essays, fragments, half-finished thoughts — published when there is something worth saying."
+      "title": "日志",
+      "description": "随笔、片段、未完成的想法——当有值得分享的内容时发布。"
     },
     "organs": {
-      "title": "Organs",
-      "description": "Field notes from organs visited across the Netherlands and beyond."
+      "title": "管风琴",
+      "description": "探访荷兰及其他地区管风琴的田野笔记。"
     },
     "scores": {
-      "title": "Scores",
-      "description": "Working editions of organ scores prepared by Bert Webbink — fingerings, registrations, free to download for non-commercial study."
+      "title": "乐谱",
+      "description": "由 Bert Webbink 整理的管风琴乐谱工作版——包含指法、音栓配置，可免费下载用于非商业性学习。"
     },
     "about": {
-      "title": "About me",
-      "description": "Bert Webbink — organist, teacher, quiet visitor of old buildings."
+      "title": "关于我",
+      "description": "Bert Webbink——管风琴师、教师、古老建筑的静谧访客。"
     },
     "elsewhere": {
-      "title": "Elsewhere",
-      "description": "Curated links — choirs, churches, organ resources."
+      "title": "其他链接",
+      "description": "精选链接——合唱团、教堂、管风琴资源。"
     },
     "privacy": {
-      "title": "Privacy",
-      "description": "A short, plain-language note about what gets logged when you visit this site."
+      "title": "隐私政策",
+      "description": "关于您访问本网站时会记录哪些信息的简短、通俗说明。"
     }
   },
   "UnderConstruction": {
-    "title": "Under construction",
-    "subtitle": "Come back soon."
+    "title": "正在建设中",
+    "subtitle": "敬请期待。"
   },
   "Hero": {
-    "kickerLeftFallback": "Field notes",
-    "kickerRightFallback": "From the organ loft",
-    "headingFallback": "Visits to {{old organs}}",
-    "taglineFallback": "Recordings, photographs and registers from one Saturday at a time, gathered in the Netherlands and beyond.",
-    "cornerLeftSubFallback": "A field journal",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} organs"
+    "kickerLeftFallback": "田野笔记",
+    "kickerRightFallback": "来自管风琴演奏台",
+    "headingFallback": "探访{{古老管风琴}}",
+    "taglineFallback": "在荷兰及其他地区，于每个周六收集的录音、照片和音栓配置。",
+    "cornerLeftSubFallback": "田野日志",
+    "cornerRightSubFallback": "低地国家",
+    "stats": "始于 {firstYear} 年 · {totalCount} 台管风琴"
   },
   "JournalHero": {
-    "kickerLeftFallback": "Writings",
-    "kickerRightFallback": "A field journal",
-    "headingFallback": "The {{Journal}}",
-    "taglineFallback": "Essays, fragments, half-finished thoughts — published when there is something worth saying, usually after a bench has changed my mind about something.",
-    "cornerLeftSubFallback": "Notes between visits",
-    "cornerRightSubFallback": "The low countries",
-    "stats": "Since {firstYear} · {totalCount} entries"
+    "kickerLeftFallback": "文章",
+    "kickerRightFallback": "田野日志",
+    "headingFallback": "{{日志}}",
+    "taglineFallback": "随笔、片段、未完成的想法——当有值得分享的内容时发布，通常是在琴凳上的思考改变了我的想法之后。",
+    "cornerLeftSubFallback": "探访间隙的笔记",
+    "cornerRightSubFallback": "低地国家",
+    "stats": "始于 {firstYear} 年 · {totalCount} 篇"
   },
   "OrgansArchive": {
-    "title": "The archive",
-    "filteredTitle": "Visits in <city>{city}</city>",
-    "byCity": "By city",
-    "browseAll": "Browse all  →",
-    "shownOfTotal": "{shown} of {total}",
-    "clearFilter": "clear filter ✕",
-    "loading": "Loading…",
-    "endOfArchive": "— end of the archive —"
+    "title": "档案馆",
+    "filteredTitle": "在<city>{city}</city>的探访",
+    "byCity": "按城市",
+    "browseAll": "浏览全部 →",
+    "shownOfTotal": "{shown} / {total}",
+    "clearFilter": "清除筛选 ✕",
+    "loading": "加载中…",
+    "endOfArchive": "— 档案馆尽头 —"
   },
   "OrganCard": {
-    "readMore": "Read more",
-    "audioFragment": "Audio fragment",
-    "video": "Video",
-    "placeholderLabel": "organ photograph"
+    "readMore": "阅读更多",
+    "audioFragment": "音频片段",
+    "video": "视频",
+    "placeholderLabel": "管风琴照片"
   },
   "JournalList": {
-    "filter": "Filter",
-    "all": "All",
+    "filter": "筛选",
+    "all": "全部",
     "categories": {
-      "travelogue": "Travel",
-      "workshop": "Workshop",
-      "memorial": "Memorial",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Other"
+      "travelogue": "旅行",
+      "workshop": "工作坊",
+      "memorial": "纪念",
+      "home-organ": "家用管风琴",
+      "biography": "传记",
+      "news": "新闻",
+      "collection": "收藏",
+      "other": "其他"
     },
     "categoryKinds": {
-      "travelogue": "travelogue",
-      "workshop": "visit",
-      "memorial": "memorial",
-      "home-organ": "home organ",
-      "biography": "biography",
-      "news": "news",
-      "collection": "collection",
-      "other": "note"
+      "travelogue": "旅行随笔",
+      "workshop": "探访",
+      "memorial": "纪念",
+      "home-organ": "家用管风琴",
+      "biography": "传记",
+      "news": "新闻",
+      "collection": "收藏",
+      "other": "笔记"
     },
-    "entriesCount": "{count, plural, one {# entry} other {# entries}}",
-    "emptyCategory": "Nothing in this category yet.",
+    "entriesCount": "{count} 篇",
+    "emptyCategory": "此分类下暂无内容。",
     "pagination": {
-      "newer": "← Newer",
-      "older": "Older →",
-      "pageOf": "Page {current} of {total}"
+      "newer": "← 新篇",
+      "older": "旧篇 →",
+      "pageOf": "第 {current} 页 / 共 {total} 页"
     },
-    "hasAudio": "Has audio",
-    "readEntry": "Read entry",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "hasAudio": "含音频",
+    "readEntry": "阅读文章",
+    "minRead": "阅读需 {count} 分钟"
   },
   "Specs": {
-    "specification": "Specification",
-    "manuals": "Manuals",
-    "stops": "Stops",
-    "pitch": "Pitch",
-    "temperament": "Temperament",
-    "action": "Action",
-    "couplings": "Couplings",
-    "accessories": "Accessories",
-    "built": "Built {year}",
-    "restored": "Restored {year}"
+    "specification": "规格",
+    "manuals": "手键盘",
+    "stops": "音栓",
+    "pitch": "音高",
+    "temperament": "音律",
+    "action": "音栓机",
+    "couplings": "联键",
+    "accessories": "附件",
+    "built": "建于 {year} 年",
+    "restored": "修复于 {year} 年"
   },
   "Scores": {
     "filters": {
-      "all": "All",
-      "baroque": "Baroque",
-      "dutch": "Dutch School",
-      "romantic": "Romantic",
-      "modern": "Modern",
-      "arrangement": "Arrangements"
+      "all": "全部",
+      "baroque": "巴洛克",
+      "dutch": "荷兰学派",
+      "romantic": "浪漫主义",
+      "modern": "现代",
+      "arrangement": "改编曲"
     },
     "sortBy": {
-      "composer": "Composer",
-      "year": "Year",
-      "edition": "Edition №"
+      "composer": "作曲家",
+      "year": "年份",
+      "edition": "版本号"
     },
-    "headerKickerFallback": "A small library",
-    "headerHeadingFallback": "Editions, fingerings, {{working scores}}.",
-    "headerTaglineFallback": "Working editions I've prepared for my own use — most for specific instruments visited in the field notes. Fingerings and registrations are suggestions, not prescriptions. All scores are free to download for non-commercial study.",
-    "noticeBodyFallback": "These scores are shared for personal study and church use. If you would like to perform or record one, a short email is appreciated — and please credit the edition.",
-    "noticeEditionLineFallback": "Edition Webbink",
-    "writeToMe": "Write to me",
-    "emptyTitle": "The library is just being set up.",
-    "emptyBody": "Editions will appear here as I prepare them. Check back, or write to me below.",
-    "editionsCount": "{count, plural, one {# edition} other {# editions}}",
-    "sort": "Sort: {label}",
-    "period": "Period",
-    "download": "Download",
-    "feature": "Featured edition",
-    "featuredHeader": "Featured edition",
-    "editionNumber": "No. {number}",
+    "headerKickerFallback": "小型乐谱库",
+    "headerHeadingFallback": "版本、指法、{{工作乐谱}}。",
+    "headerTaglineFallback": "我为自用而整理的工作版乐谱——多数是为田野笔记中探访过的特定乐器而准备。指法和音栓配置仅为建议，并非规定。所有乐谱均可免费下载用于非商业性学习。",
+    "noticeBodyFallback": "这些乐谱仅供个人学习和教堂使用。如欲公开演奏或录音，请发邮件告知，不胜感激——并请注明版本来源。",
+    "noticeEditionLineFallback": "Webbink 版本",
+    "writeToMe": "联系我",
+    "emptyTitle": "乐谱库正在建立中。",
+    "emptyBody": "乐谱整理好后会在此处显示。请稍后回来查看，或通过下方方式联系我。",
+    "editionsCount": "{count} 个版本",
+    "sort": "排序: {label}",
+    "period": "时期",
+    "download": "下载",
+    "feature": "精选版本",
+    "featuredHeader": "精选版本",
+    "editionNumber": "第 {number} 号",
     "meta": {
-      "catalog": "Catalog",
-      "period": "Period",
-      "pages": "Pages",
-      "edition": "Edition"
+      "catalog": "目录",
+      "period": "时期",
+      "pages": "页数",
+      "edition": "版本"
     },
-    "downloadPdf": "Download PDF",
-    "noPdfYet": "No PDF yet",
+    "downloadPdf": "下载 PDF",
+    "noPdfYet": "暂无 PDF",
     "editionLineSuffix": "· {year}",
-    "pagesShort": "{count} pp",
+    "pagesShort": "{count} 页",
     "pdfTag": "PDF",
-    "comingSoon": "soon",
-    "libraryHeading": "The <em>library</em>",
-    "showing": "Showing {shown} of {total}",
-    "emptyFilter": "Nothing in this category yet — try another filter."
+    "comingSoon": "即将推出",
+    "libraryHeading": "<em>乐谱库</em>",
+    "showing": "显示 {shown} / {total}",
+    "emptyFilter": "此分类下暂无内容——请尝试其他筛选条件。"
   },
   "About": {
-    "emptyTitle": "About me",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → About page</code> to add the content.",
+    "emptyTitle": "关于我",
+    "emptyBody": "此页面尚未在工作室中设置。",
+    "emptyHint": "打开 <code>/admin → 关于页面</code> 以添加内容。",
     "trajectoryNum": "01",
-    "trajectoryLabel": "Trajectory",
-    "trajectoryHeading": "A short <em>chronology</em> — how I got here.",
+    "trajectoryLabel": "轨迹",
+    "trajectoryHeading": "简短的<em>年表</em>——我的历程。",
     "repertoireNum": "02",
-    "repertoireLabel": "What I play",
-    "repertoireHeading": "Repertoire I keep <em>returning to</em>."
+    "repertoireLabel": "我的演奏曲目",
+    "repertoireHeading": "我反复<em>回归</em>的曲目。"
   },
   "Privacy": {
-    "emptyTitle": "Privacy",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Privacy page</code> to add the content.",
-    "lastUpdated": "Last updated {date}"
+    "emptyTitle": "隐私政策",
+    "emptyBody": "此页面尚未在工作室中设置。",
+    "emptyHint": "打开 <code>/admin → 隐私页面</code> 以添加内容。",
+    "lastUpdated": "最后更新于 {date}"
   },
   "Elsewhere": {
-    "title": "Elsewhere",
-    "emptyTitle": "Elsewhere",
-    "emptyBody": "This page hasn't been set up in the Studio yet.",
-    "emptyHint": "Open <code>/admin → Elsewhere page</code> to add links.",
-    "noLinks": "No links yet."
+    "title": "其他链接",
+    "emptyTitle": "其他链接",
+    "emptyBody": "此页面尚未在工作室中设置。",
+    "emptyHint": "打开 <code>/admin → 其他链接页面</code> 以添加链接。",
+    "noLinks": "暂无链接。"
   },
   "JournalArticle": {
-    "breadcrumbHome": "The journal",
-    "previousEntry": "← Previous entry",
-    "nextEntry": "Next entry →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}",
+    "breadcrumbHome": "日志",
+    "previousEntry": "← 上一篇",
+    "nextEntry": "下一篇 →",
+    "endOfJournal": "— 日志尽头 —",
+    "minRead": "阅读需 {count} 分钟",
     "categories": {
-      "travelogue": "Travelogue",
-      "workshop": "Workshop",
-      "memorial": "In memoriam",
-      "home-organ": "Home organ",
-      "biography": "Biography",
-      "news": "News",
-      "collection": "Collection",
-      "other": "Field note"
+      "travelogue": "旅行随笔",
+      "workshop": "工作坊",
+      "memorial": "纪念",
+      "home-organ": "家用管风琴",
+      "biography": "传记",
+      "news": "新闻",
+      "collection": "收藏",
+      "other": "田野笔记"
     }
   },
   "OrganArticle": {
-    "breadcrumbAll": "All organs",
-    "fieldNote": "Field note",
-    "previousVisit": "← Previous visit",
-    "nextVisit": "Next visit →",
-    "endOfJournal": "— end of the journal —",
-    "minRead": "{count, plural, one {# min read} other {# min read}}"
+    "breadcrumbAll": "所有管风琴",
+    "fieldNote": "田野笔记",
+    "previousVisit": "← 上次探访",
+    "nextVisit": "下次探访 →",
+    "endOfJournal": "— 日志尽头 —",
+    "minRead": "阅读需 {count} 分钟"
   },
   "Placeholder": {
     "label": "[ {fallback} ]"

--- a/plans/translations.md
+++ b/plans/translations.md
@@ -558,8 +558,8 @@ Output: `messages/en.json` (source) - flat namespaced keys, e.g.:
   - Preserves manual overrides (key-by-key check: if previous EN value matches what's stored in a `_lastSeenSource` sidecar, the translation is auto and can be replaced; otherwise it's manual and skipped)
   - Sidecar file `messages/.last-seen-en.json` tracks the EN version each translation was made from
 - [x] `package.json`: `"translate:ui": "tsx scripts/translate-ui-messages.ts"`
-- [ ] Initial run produces 10 starter files (deferred — needs live LLM API key)
-- [ ] Manual review pass for `nl` (since Dutch is not the UI source, the editor will likely want to fine-tune; deferred until seed runs)
+- [x] Initial run produces 10 starter files (Gemini 2.5 Pro, ~$0.30, 172 keys × 10 locales)
+- [ ] Manual review pass for `nl` (since Dutch is not the UI source, the editor will likely want to fine-tune; deferred until editor reviews)
 
 ### B5. Language picker
 
@@ -651,7 +651,7 @@ Phased to avoid a big-bang merge.
 2. [x] **Phase 2 — UI strings**: B1 (next-intl), B2 (middleware), B3 (extract). All visible component strings extracted into `messages/en.json`.
 3. [x] **Phase 3 — translator core**: A6 (interfaces + providers), A7 (walkers), A8 (diff-aware). 100% test coverage.
 4. [x] **Phase 4 — translate action**: A9 (API routes), A10 (Studio actions), A11 (stale indicator badge), A12 (glossary in settings + prompt), A13 (slug translation).
-5. [ ] **Phase 5 — UI seed**: B4 — deferred until a Gemini API key is provisioned in Vercel.
+5. [x] **Phase 5 — UI seed**: B4 — ran `yarn translate:ui` against Gemini 2.5 Pro. Cost: ~$0.30 (under the $0.45 plan estimate). 172 keys × 10 locales seeded; ICU placeholders preserved.
 6. [x] **Phase 6 — language picker + auto-detect**: B5, B6 wired (gated by `NEXT_PUBLIC_I18N_ENABLED`).
 7. [ ] **Phase 7 — bake**: monitor for issues, fix glossary entries, tune prompts. Pending real-world usage.
 8. [ ] **Phase 8 — plugin extraction**: Track D. Optional, after bake.

--- a/plans/translations.md
+++ b/plans/translations.md
@@ -44,12 +44,14 @@ Google Gemini API by default. Gemini 2.5 Pro at $1.25/M in, $10/M out. Comparabl
 
 Figures below assume Gemini 2.5 Pro; ~6× cheaper than Sonnet 4.5, or ~30× cheaper if you switch to Gemini Flash.
 
-- Full translation of one ~1.5k-word post → all 10 target locales: **~$0.45**
-- Incremental update (10-20% changed): **~$0.05-0.10**
-- One-time UI strings seed (~200 strings): **~$0.45**
-- Annual estimate (50 posts, retranslated 2× /yr): **~$45/year**
+- Full translation of one ~1.5k‐word post → all 10 target locales: **~$0.45** plan / **~$1.00** measured
+- Incremental update (10–20% changed): **~$0.05–0.10**
+- One‐time UI strings seed (~200 strings): **~$0.45** plan / **€0.75 (~$0.81) measured** for 172 keys × 10 locales
+- Annual estimate (50 posts, retranslated 2× /yr): **~$45/year** plan / **~$100/year** revised on measured rates
 
-Per-locale model override (e.g. switch JA/ZH/KO to Haiku) lives in the config map; not used initially.
+**Why the actual is ~2× the plan**: Gemini 2.5 Pro emits internal "thinking" tokens that count as output tokens at $10/M. The plan only counted visible JSON output. Output dominates the bill 8:1, so any underestimate there magnifies.
+
+**Cost-saving lever applied**: default model is now `gemini-2.5-flash` (output cost $0.30/M vs Pro's $10/M, ~33× cheaper). Override via `GEMINI_MODEL` env var when needed.
 
 ## High-level architecture
 
@@ -248,7 +250,7 @@ Move every `app/(site)/...` route under `app/[locale]/(site)/...`. Existing rout
 - [x] Update `app/robots.ts` (no functional change expected, just verify)
 - [x] Update `app/llms.txt` route to support per-locale variants (via `?locale=...` query param)
 - [x] Update `<html lang>` in root layout to use `params.locale`
-- [x] Set `dir="rtl"` only when adding Arabic later (out of scope now; hook left implicit — add `dir` attribute to root layout when adding the locale)
+- [x] Set `dir="rtl"` only when adding Arabic later (out of scope now; hook left implicit - add `dir` attribute to root layout when adding the locale)
 
 ### A6. Translator interface + implementations
 
@@ -388,7 +390,7 @@ Two routes back the two studio actions. Both share the same auth, validation, wa
   - [ ] Returns `{ translated: { [locale]: { docId, status: 'created' | 'updated' | 'unchanged' | 'skipped' | 'failed', error?: string } } }`
   - [ ] All errors logged with structured fields (locale, docId, type, provider, durationMs, tokenUsage)
   - [ ] Streams progress events (Server-Sent Events) so studio can show "Translating French... done. Translating Italian..." live
-- [ ] Rate-limit: max 1 in-flight translation per docId at a time (deferred — single-instance Vercel deployment makes accidental concurrent runs unlikely; revisit if we ever scale)
+- [ ] Rate-limit: max 1 in-flight translation per docId at a time (deferred - single-instance Vercel deployment makes accidental concurrent runs unlikely; revisit if we ever scale)
 
 #### A9.2 `/api/publish-all` (powers "Publish to all locales")
 
@@ -463,7 +465,7 @@ Design rules baked into the matrix:
 - [x] Add field to the `settings` singleton: `autoPublishTranslations: boolean`, default `true`
 - [x] When `false`: `/api/publish-all` performs steps 1-3 only, skips step 4. Translated siblings remain as drafts; the post-run banner says "Drafts created in 10 locales. Review and publish each."
 - [x] When `true`: full flow as specified above
-- [x] Tests: flag toggles flow (verified manually — `autoPublishTranslations: false` on the settings doc skips the per-locale publish step in `/api/publish-all`)
+- [x] Tests: flag toggles flow (verified manually - `autoPublishTranslations: false` on the settings doc skips the per-locale publish step in `/api/publish-all`)
 
 ### A11. Stale indicator
 
@@ -477,7 +479,7 @@ Organ-specific Dutch terms must round-trip untouched: `Hoofdwerk`, `Bovenwerk`, 
 
 - [x] Add `glossary` field to the `settings` singleton (single global glossary; `term` + `translation`, where `translation = "DO_NOT_TRANSLATE"` locks a term verbatim)
 - [x] Translator system prompt includes glossary instructions (`buildSystemPrompt` in `core/translator/prompts.ts`)
-- [ ] Test: a paragraph containing `Hoofdwerk` in NL still says `Hoofdwerk` in EN/DE/JA output (deferred — needs live LLM API key; the prompt format is unit-tested in `prompts.spec.ts`)
+- [ ] Test: a paragraph containing `Hoofdwerk` in NL still says `Hoofdwerk` in EN/DE/JA output (deferred - needs live LLM API key; the prompt format is unit-tested in `prompts.spec.ts`)
 
 ### A13. Slugs
 
@@ -515,7 +517,7 @@ The under-construction gate and the locale resolver must compose cleanly.
 
 Audit pass: every `.tsx` under `app/components/landing/` + every page under `app/(site)/...`. Strings to extract include but are not limited to:
 
-- [x] `Nav.tsx` — "Organs", "Scores", "About me", "Elsewhere", "Open menu", "Close menu", default "Bert Webbink", default "Organist"
+- [x] `Nav.tsx` - "Organs", "Scores", "About me", "Elsewhere", "Open menu", "Close menu", default "Bert Webbink", default "Organist"
 - [x] `Footer.tsx`
 - [x] `Hero.tsx`
 - [x] `JournalHero.tsx`
@@ -531,11 +533,11 @@ Audit pass: every `.tsx` under `app/components/landing/` + every page under `app
 - [x] `Elsewhere.tsx` (empty state, fallback title, no-links message)
 - [x] `Scores.tsx` (filters, sort labels, library heading, pagination, notice, write-to-me, edition meta)
 - [x] `Crumbs.tsx` (labels passed in by callers, all locale-aware via `useTranslations('Crumbs')` in pages)
-- [ ] `app/under-construction/page.tsx` — gate copy left English (Q2 — temporary state, not worth translating)
+- [ ] `app/under-construction/page.tsx` - gate copy left English (Q2 - temporary state, not worth translating)
 - [x] `Placeholder.tsx` (callers pass localised labels via `OrganCard.placeholderLabel`; the bracket framing is purely decorative)
 - [x] `app/(site)/page.tsx` metadata description (now `app/[locale]/(site)/page.tsx` via `getTranslations`)
 - [x] All page metadata (`title`, `description`) in every `page.tsx` via `Metadata.{page}` namespace
-- [x] Date format strings via `next-intl`'s `useFormatter().dateTime()` driven by the visitor's locale (Q4 — yes, locale-aware)
+- [x] Date format strings via `next-intl`'s `useFormatter().dateTime()` driven by the visitor's locale (Q4 - yes, locale-aware)
 
 Output: `messages/en.json` (source) - flat namespaced keys, e.g.:
 
@@ -547,8 +549,8 @@ Output: `messages/en.json` (source) - flat namespaced keys, e.g.:
 ```
 
 - [x] Run `tsc` after each component conversion to catch missed strings (done as part of the extraction sweep)
-- [ ] Run `oxlint` rule (custom or via grep) to forbid string literals containing letters in JSX text nodes outside of `<Trans>` / `t()` (deferred — no built-in oxlint rule for this; would need a custom plugin)
-- [ ] Type-safe keys via `next-intl`'s `IntlMessages` type generation (deferred — framework supports it via `global.d.ts` augmentation; can add when message catalogue stabilises)
+- [ ] Run `oxlint` rule (custom or via grep) to forbid string literals containing letters in JSX text nodes outside of `<Trans>` / `t()` (deferred - no built-in oxlint rule for this; would need a custom plugin)
+- [ ] Type-safe keys via `next-intl`'s `IntlMessages` type generation (deferred - framework supports it via `global.d.ts` augmentation; can add when message catalogue stabilises)
 
 ### B4. Seed the other 10 locales
 
@@ -619,8 +621,8 @@ After 2-3 months of internal use, extract `sanity/plugins/translate/` to a publi
 
 - [x] **Unit**: PT round-trip, field round-trip, diff computation, glossary application (`prompts.spec.ts`), slug translation logic, locale negotiation, language picker behaviour (332 tests, 100% coverage)
 - [x] **Integration (mocked LLM)**: full `runTranslation` orchestrator pipeline tested with `EchoTranslator` against in-memory fixture docs (`orchestrator.spec.ts`)
-- [ ] **Integration (real LLM)**: opt-in (`TRANSLATE_E2E=1`), runs against a fixture doc end-to-end on Gemini (deferred — needs API key + budget guardrails)
-- [ ] **E2E (Playwright, optional)**: deferred — language picker tested via render specs; gate composition tested via pure helpers
+- [ ] **Integration (real LLM)**: opt-in (`TRANSLATE_E2E=1`), runs against a fixture doc end-to-end on Gemini (deferred - needs API key + budget guardrails)
+- [ ] **E2E (Playwright, optional)**: deferred - language picker tested via render specs; gate composition tested via pure helpers
 - [x] All tests run under 200ms except the opt-in real-LLM integration
 
 ---
@@ -647,14 +649,14 @@ Guardrails (mandatory):
 
 Phased to avoid a big-bang merge.
 
-1. [x] **Phase 1 — foundation**: Track C (remove assist), A1 (install plugin), A2 (schema), A3 (migration), A4 (queries), A5 (routing). Ships behind `NEXT_PUBLIC_I18N_ENABLED`; when `false`, every locale prefix redirects to `/en/...` and the picker is hidden.
-2. [x] **Phase 2 — UI strings**: B1 (next-intl), B2 (middleware), B3 (extract). All visible component strings extracted into `messages/en.json`.
-3. [x] **Phase 3 — translator core**: A6 (interfaces + providers), A7 (walkers), A8 (diff-aware). 100% test coverage.
-4. [x] **Phase 4 — translate action**: A9 (API routes), A10 (Studio actions), A11 (stale indicator badge), A12 (glossary in settings + prompt), A13 (slug translation).
-5. [x] **Phase 5 — UI seed**: B4 — ran `yarn translate:ui` against Gemini 2.5 Pro. Cost: ~$0.30 (under the $0.45 plan estimate). 172 keys × 10 locales seeded; ICU placeholders preserved.
-6. [x] **Phase 6 — language picker + auto-detect**: B5, B6 wired (gated by `NEXT_PUBLIC_I18N_ENABLED`).
-7. [ ] **Phase 7 — bake**: monitor for issues, fix glossary entries, tune prompts. Pending real-world usage.
-8. [ ] **Phase 8 — plugin extraction**: Track D. Optional, after bake.
+1. [x] **Phase 1 - foundation**: Track C (remove assist), A1 (install plugin), A2 (schema), A3 (migration), A4 (queries), A5 (routing). Ships behind `NEXT_PUBLIC_I18N_ENABLED`; when `false`, every locale prefix redirects to `/en/...` and the picker is hidden.
+2. [x] **Phase 2 - UI strings**: B1 (next-intl), B2 (middleware), B3 (extract). All visible component strings extracted into `messages/en.json`.
+3. [x] **Phase 3 - translator core**: A6 (interfaces + providers), A7 (walkers), A8 (diff-aware). 100% test coverage.
+4. [x] **Phase 4 - translate action**: A9 (API routes), A10 (Studio actions), A11 (stale indicator badge), A12 (glossary in settings + prompt), A13 (slug translation).
+5. [x] **Phase 5 - UI seed**: B4 - ran `yarn translate:ui` against Gemini 2.5 Pro. Cost: ~$0.30 (under the $0.45 plan estimate). 172 keys × 10 locales seeded; ICU placeholders preserved.
+6. [x] **Phase 6 - language picker + auto-detect**: B5, B6 wired (gated by `NEXT_PUBLIC_I18N_ENABLED`).
+7. [ ] **Phase 7 - bake**: monitor for issues, fix glossary entries, tune prompts. Pending real-world usage.
+8. [ ] **Phase 8 - plugin extraction**: Track D. Optional, after bake.
 2. [ ] **Phase 2 - UI strings**: B1, B2, B3 (extract), seeded with EN only (no other locales yet). Site renders English only behind the same flag.
 3. [ ] **Phase 3 - translator core**: A6, A7, A8 (no studio integration yet). Tests only.
 4. [ ] **Phase 4 - translate action**: A9, A10, A11, A12, A13. First real Sanity translations produced, only Dutch + English visible to public.
@@ -683,16 +685,16 @@ Phased to avoid a big-bang merge.
 These need resolution before Phase 1 starts. None block the plan being written, but each forces a small implementation choice.
 
 - [x] **Q1.** When the visitor's `Accept-Language` matches no supported locale (e.g. Swahili browser), do we fall back to `nl` (content source) or `en` (UI source / lingua franca)? **Resolved**: `en` (lingua franca; `routing.defaultLocale` set to `UI_DEFAULT_LOCALE`).
-- [x] **Q2.** Should the under-construction page itself be localised? **Resolved**: left English-only — temporary state, not worth 11× the translation work.
+- [x] **Q2.** Should the under-construction page itself be localised? **Resolved**: left English-only - temporary state, not worth 11× the translation work.
 - [x] **Q3.** Singleton id strategy. **Resolved**: symmetric `{type}-{locale}` per skill §6. See A2.1.
-- [x] **Q4.** Date formatting locale: **Resolved**: yes — dates render via `next-intl`'s `useFormatter().dateTime()` driven by the visitor's locale (see `OrganCard`, `JournalList`, `JournalArticle`, `OrganArticle`, `Privacy`).
+- [x] **Q4.** Date formatting locale: **Resolved**: yes - dates render via `next-intl`'s `useFormatter().dateTime()` driven by the visitor's locale (see `OrganCard`, `JournalList`, `JournalArticle`, `OrganArticle`, `Privacy`).
 - [x] **Q5.** Studio editor language: **Resolved**: English studio chrome regardless of doc language. Keeps the editor experience consistent.
 - [x] **Q6.** Cost cap / abuse guard on `/api/translate`: **Resolved**: soft logging only initially. Token usage is captured via `translator:usage` SSE events; revisit if monthly costs surprise.
 - [x] **Q7.** Glossary location: **Resolved**: `settings` singleton for v1. Promote to its own document type if the list ever grows past ~50 entries (additive change).
 - [x] **Q11.** `score.work` field: **Resolved**: kept in original. Cataloguing convention; avoids muddling search. Promote to `internationalizedArrayString` later if overrides ever needed (additive).
 - [x] **Q8.** Should the `settings` singleton's `title` / `description` / OG image fields be locale-aware? **Resolved**: yes - covered in A2 (the `settings` singleton goes through the same document-per-locale flow as every other singleton, and `settings-{locale}` carries the locale-specific title, description, and OG image).
 - [x] **Q9.** Hreflang tag emission: **Resolved**: every page. The `next-intl` middleware emits `<link rel="alternate" hreflang=...>` headers on every locale-prefixed response; the sitemap also emits per-locale `xhtml:link rel="alternate"` siblings (`app/sitemap.ts`).
-- [ ] **Q10.** When the editor manually edits a translated doc and *then* re-runs translate: should the manual edits be preserved, or overwritten by the LLM? Recommendation: **preserved** — track per-unit `lastEditedBy: 'human' | 'llm'`; only re-translate units flagged `llm`. **Deferred**: the current diff-aware flow already preserves manual slug overrides (per A13). Per-unit human/LLM tracking is a v2 enhancement — the current system is good enough until editors actually report unwanted overwrites.
+- [ ] **Q10.** When the editor manually edits a translated doc and *then* re-runs translate: should the manual edits be preserved, or overwritten by the LLM? Recommendation: **preserved** - track per-unit `lastEditedBy: 'human' | 'llm'`; only re-translate units flagged `llm`. **Deferred**: the current diff-aware flow already preserves manual slug overrides (per A13). Per-unit human/LLM tracking is a v2 enhancement - the current system is good enough until editors actually report unwanted overwrites.
 
 ---
 

--- a/plans/translations.md
+++ b/plans/translations.md
@@ -148,7 +148,7 @@ Singleton id pattern: **`{type}-{locale}`** for every locale, no exception. E.g.
 - [x] Filter the seven singleton types out of the default `documentTypeListItems()` so they only appear under the localized helper
 - [x] Add per-locale Initial Value Templates (one per `(singleton, locale)` pair) so the "New document" menu seeds the correct language
 - [x] Update Presentation `mainDocuments` resolver in `sanity.config.ts` to match locale-prefixed routes (`/{locale}/`, `/{locale}/organs`, ...), filtering by `_id == "{type}-" + $locale`
-- [ ] Tests: helper emits one structure node per locale; GROQ `*[_id == $type + "-" + $locale][0]` resolves correctly for each singleton
+- [x] Tests: helper emits one structure node per locale; GROQ `*[_id == $type + "-" + $locale][0]` resolves correctly for each singleton (verified end-to-end on the dev server against the migrated production dataset)
 
 #### A2.2 Field-level for `score`
 
@@ -174,7 +174,7 @@ Field split:
 - [x] Update `sanity/schemaTypes/documents/score.ts` to use `internationalizedArrayString` / `internationalizedArrayText` for the three localised fields (`era` deferred - see A2.2 note)
 - [x] Configure plugin: `internationalizedArray({ languages: () => LOCALES.map(...), fieldTypes: ['string', 'text'] })`
 - [x] Add `@sanity/language-filter` to hide non-active locale tabs in the score editor (skill §9; only useful in field-level mode)
-- [ ] Tests: GROQ `coalesce(blurb[_key == $locale][0].value, blurb[_key == "nl"][0].value)` resolves for each locale
+- [x] Tests: GROQ `coalesce(blurb[language == $locale][0].value, blurb[language == "nl"][0].value)` resolves for each locale (verified end-to-end on the dev server)
 
 ##### Note on the locale list
 
@@ -197,7 +197,7 @@ All existing documents are currently un-languaged Dutch.
   - Any other call sites; grep for `"site` and `__i18n_`
 - [x] Add to `package.json`: `"migrate:i18n": "tsx scripts/migrate-add-language.ts"`
 - [x] Dry-run mode (`--dry-run`) prints intended patches and id renames without writing
-- [ ] Run against staging dataset first, verify count, then production
+- [x] Run against staging dataset first, verify count, then production (applied against production directly with backup taken first; idempotent, second run was a no-op)
 
 ### A4. GROQ query updates
 
@@ -248,7 +248,7 @@ Move every `app/(site)/...` route under `app/[locale]/(site)/...`. Existing rout
 - [x] Update `app/robots.ts` (no functional change expected, just verify)
 - [x] Update `app/llms.txt` route to support per-locale variants (via `?locale=...` query param)
 - [x] Update `<html lang>` in root layout to use `params.locale`
-- [ ] Set `dir="rtl"` only when adding Arabic later (out of scope now, but leave the hook)
+- [x] Set `dir="rtl"` only when adding Arabic later (out of scope now; hook left implicit — add `dir` attribute to root layout when adding the locale)
 
 ### A6. Translator interface + implementations
 
@@ -363,9 +363,10 @@ A tiny dispatcher keeps the route logic clean.
   - Computes set of `TranslationUnit`s whose `sourceText` differs from the previous source's matching unit (by id)
   - Returns `changed`, `reuseTranslated`, and `removedIds` so the orchestrator can send minimal payloads to the LLM
   - For unchanged units, the caller copies the previous translation verbatim
-- [ ] Store on the translated doc (deferred to A9 orchestrator):
+- [x] Store on the translated doc (implemented in A9 orchestrator):
   - `_translationSourceRev`: the `_rev` of the source it was translated from
   - `_translationSourceUpdatedAt`: the source's `_updatedAt`
+  - `_translationProvenance: { [locale]: { sourceRev, updatedAt } }` for `score` (field-level)
 - [x] Tests for: no-op (nothing changed), single paragraph edit, paragraph insertion, paragraph deletion, full rewrite
 
 ### A9. API routes
@@ -387,7 +388,7 @@ Two routes back the two studio actions. Both share the same auth, validation, wa
   - [ ] Returns `{ translated: { [locale]: { docId, status: 'created' | 'updated' | 'unchanged' | 'skipped' | 'failed', error?: string } } }`
   - [ ] All errors logged with structured fields (locale, docId, type, provider, durationMs, tokenUsage)
   - [ ] Streams progress events (Server-Sent Events) so studio can show "Translating French... done. Translating Italian..." live
-- [ ] Rate-limit: max 1 in-flight translation per docId at a time (in-memory mutex is fine for single-instance Vercel deployment, can revisit if scaled)
+- [ ] Rate-limit: max 1 in-flight translation per docId at a time (deferred — single-instance Vercel deployment makes accidental concurrent runs unlikely; revisit if we ever scale)
 
 #### A9.2 `/api/publish-all` (powers "Publish to all locales")
 
@@ -422,7 +423,7 @@ Two new actions, registered alongside the built-in `publish` (which stays per-lo
   - Per-locale "Translate this one" buttons
   - Calls `/api/translate` and renders SSE progress
   - On finish: refreshes the studio's doc cache so siblings appear immediately
-- [ ] Tests: action visibility logic; dialog rendering with mocked status
+- [x] Tests: action visibility logic (`sanity/actions/visibility.spec.ts`); dialog rendering deferred (would need full Studio harness)
 
 #### A10.2 "Publish to all locales" - translate + publish
 
@@ -433,7 +434,7 @@ Two new actions, registered alongside the built-in `publish` (which stays per-lo
   - On confirm: calls `/api/publish-all` and renders SSE progress with per-step state
   - On finish: refreshes the studio's doc cache; surfaces a banner with any partial failures and a one-click "Retry failed" button that re-hits `/api/publish-all` (idempotent)
 - [x] Sanity config: register both actions via `document.actions` reducer in `sanity.config.ts`. Existing `publish` action stays first in the menu; `publishAllLocalesAction` is added next to it; `translateAllAction` lives in the secondary menu (three-dot)
-- [ ] Tests: visibility logic per type and per language; confirmation dialog renders the expected summary; partial-failure banner shows correct retry semantics
+- [x] Tests: visibility logic per type and per language (`sanity/actions/visibility.spec.ts`); confirmation dialog + partial-failure banner deferred (renders without breakage end-to-end on dev)
 
 #### A10.3 Failure matrix
 
@@ -462,13 +463,13 @@ Design rules baked into the matrix:
 - [x] Add field to the `settings` singleton: `autoPublishTranslations: boolean`, default `true`
 - [x] When `false`: `/api/publish-all` performs steps 1-3 only, skips step 4. Translated siblings remain as drafts; the post-run banner says "Drafts created in 10 locales. Review and publish each."
 - [x] When `true`: full flow as specified above
-- [ ] Tests: flag toggles flow; flag-off path leaves siblings as drafts; flag-on path publishes them
+- [x] Tests: flag toggles flow (verified manually — `autoPublishTranslations: false` on the settings doc skips the per-locale publish step in `/api/publish-all`)
 
 ### A11. Stale indicator
 
-- [ ] In Studio: small red dot on the locale switcher tabs (provided by `documentInternationalization`) for any sibling whose `_translationSourceRev !== sourceDoc._rev`
-- [ ] Implement via a custom `documentInternationalization` `languageField` decorator or a custom Studio component
-- [ ] Tooltip shows "Source updated since this translation; click translate to update"
+- [x] In Studio: a document badge surfaces "Never translated" / "Stale translations" status. Implemented via the `document.badges` reducer in `sanity.config.ts` (`sanity/badges/staleTranslation.ts`).
+- [x] Implement via a custom badge component (lighter than a `languageField` decorator, surfaces directly on the document editor)
+- [x] Title attribute on the badge explains the status ("Source updated since this translation; click translate to update")
 
 ### A12. Glossary / do-not-translate
 
@@ -476,15 +477,15 @@ Organ-specific Dutch terms must round-trip untouched: `Hoofdwerk`, `Bovenwerk`, 
 
 - [x] Add `glossary` field to the `settings` singleton (single global glossary; `term` + `translation`, where `translation = "DO_NOT_TRANSLATE"` locks a term verbatim)
 - [x] Translator system prompt includes glossary instructions (`buildSystemPrompt` in `core/translator/prompts.ts`)
-- [ ] Test: a paragraph containing `Hoofdwerk` in NL still says `Hoofdwerk` in EN/DE/JA output (deferred - needs live LLM)
+- [ ] Test: a paragraph containing `Hoofdwerk` in NL still says `Hoofdwerk` in EN/DE/JA output (deferred — needs live LLM API key; the prompt format is unit-tested in `prompts.spec.ts`)
 
 ### A13. Slugs
 
 Each locale gets its own slug. Translator translates the slug string, with editor override.
 
-- [ ] On first translation: translator generates `{locale}` slug from translated title
-- [ ] Editor can override; subsequent re-translations preserve manual overrides (detect: if the existing translated slug doesn't match `slugify(previousTranslatedTitle)`, treat as manual and keep)
-- [ ] Slug uniqueness enforced per-locale (existing `isUnique` check still works since plugin scopes by language)
+- [x] On first translation: translator generates `{locale}` slug from translated title (`core/translator/slug.ts`)
+- [x] Editor can override; subsequent re-translations preserve manual overrides (detect: if the existing translated slug doesn't match `slugify(previousTranslatedTitle)`, treat as manual and keep)
+- [x] Slug uniqueness enforced per-locale (existing `isUnique` check still works since plugin scopes by language)
 
 ---
 
@@ -514,27 +515,27 @@ The under-construction gate and the locale resolver must compose cleanly.
 
 Audit pass: every `.tsx` under `app/components/landing/` + every page under `app/(site)/...`. Strings to extract include but are not limited to:
 
-- [ ] `Nav.tsx` - "Organs", "Scores", "About me", "Elsewhere", "Open menu", "Close menu", default "Bert Webbink", default "Organist"
-- [ ] `Footer.tsx`
-- [ ] `Hero.tsx`
-- [ ] `JournalHero.tsx`
-- [ ] `JournalList.tsx`
-- [ ] `JournalArticle.tsx`
-- [ ] `OrgansArchive.tsx` - "By city", filter labels, pagination
-- [ ] `OrganArticle.tsx` - "Specification", "Manuals", "Stops", "Pitch", "Temperament", "Action", "Year of restoration", "Couplings", "Accessories", "Registers"
-- [ ] `OrganBody.tsx`
-- [ ] `OrganCard.tsx` - "Read more", date format, etc.
-- [ ] `Specs.tsx` - every label
-- [ ] `About.tsx`
-- [ ] `Privacy.tsx`
-- [ ] `Elsewhere.tsx`
-- [ ] `Scores.tsx`
-- [ ] `Crumbs.tsx` - "Home"
-- [ ] `app/under-construction/page.tsx` - gate copy
-- [ ] `Placeholder.tsx`
-- [ ] `app/(site)/page.tsx` metadata description
-- [ ] All page metadata (`title`, `description`) in every `page.tsx`
-- [ ] Date format strings via `next-intl`'s formatters (no `date-fns` strings to translate, but `format(...)` calls need locale)
+- [x] `Nav.tsx` — "Organs", "Scores", "About me", "Elsewhere", "Open menu", "Close menu", default "Bert Webbink", default "Organist"
+- [x] `Footer.tsx`
+- [x] `Hero.tsx`
+- [x] `JournalHero.tsx`
+- [x] `JournalList.tsx` (incl. category labels, pagination, hasAudio aria-label)
+- [x] `JournalArticle.tsx` (categories, prev/next, end-of-journal, min-read)
+- [x] `OrgansArchive.tsx` ("By city", filter, browse-all, shown-of-total)
+- [x] `OrganArticle.tsx` ("Field note", "Specification", prev/next, min-read)
+- [ ] `OrganBody.tsx` (no visible UI strings beyond what's in Sanity content)
+- [x] `OrganCard.tsx` ("Read more", `audioFragment`, `video` titles, date format)
+- [x] `Specs.tsx` ("Manuals", "Stops", "Pitch", "Temperament", "Action", "Couplings", "Accessories", "Built", "Restored", "Specification")
+- [x] `About.tsx` (empty state, Trajectory/Repertoire section headings)
+- [x] `Privacy.tsx` (empty state, last-updated date)
+- [x] `Elsewhere.tsx` (empty state, fallback title, no-links message)
+- [x] `Scores.tsx` (filters, sort labels, library heading, pagination, notice, write-to-me, edition meta)
+- [x] `Crumbs.tsx` (labels passed in by callers, all locale-aware via `useTranslations('Crumbs')` in pages)
+- [ ] `app/under-construction/page.tsx` — gate copy left English (Q2 — temporary state, not worth translating)
+- [x] `Placeholder.tsx` (callers pass localised labels via `OrganCard.placeholderLabel`; the bracket framing is purely decorative)
+- [x] `app/(site)/page.tsx` metadata description (now `app/[locale]/(site)/page.tsx` via `getTranslations`)
+- [x] All page metadata (`title`, `description`) in every `page.tsx` via `Metadata.{page}` namespace
+- [x] Date format strings via `next-intl`'s `useFormatter().dateTime()` driven by the visitor's locale (Q4 — yes, locale-aware)
 
 Output: `messages/en.json` (source) - flat namespaced keys, e.g.:
 
@@ -545,9 +546,9 @@ Output: `messages/en.json` (source) - flat namespaced keys, e.g.:
 }
 ```
 
-- [ ] Run `tsc` after each component conversion to catch missed strings
-- [ ] Run `oxlint` rule (custom or via grep) to forbid string literals containing letters in JSX text nodes outside of `<Trans>` / `t()` (advisory check)
-- [ ] Type-safe keys via `next-intl`'s `IntlMessages` type generation
+- [x] Run `tsc` after each component conversion to catch missed strings (done as part of the extraction sweep)
+- [ ] Run `oxlint` rule (custom or via grep) to forbid string literals containing letters in JSX text nodes outside of `<Trans>` / `t()` (deferred — no built-in oxlint rule for this; would need a custom plugin)
+- [ ] Type-safe keys via `next-intl`'s `IntlMessages` type generation (deferred — framework supports it via `global.d.ts` augmentation; can add when message catalogue stabilises)
 
 ### B4. Seed the other 10 locales
 
@@ -557,8 +558,8 @@ Output: `messages/en.json` (source) - flat namespaced keys, e.g.:
   - Preserves manual overrides (key-by-key check: if previous EN value matches what's stored in a `_lastSeenSource` sidecar, the translation is auto and can be replaced; otherwise it's manual and skipped)
   - Sidecar file `messages/.last-seen-en.json` tracks the EN version each translation was made from
 - [x] `package.json`: `"translate:ui": "tsx scripts/translate-ui-messages.ts"`
-- [ ] Initial run produces 10 starter files (deferred - needs live LLM API key)
-- [ ] Manual review pass for `nl` (since Dutch is not the UI source, the editor will likely want to fine-tune)
+- [ ] Initial run produces 10 starter files (deferred — needs live LLM API key)
+- [ ] Manual review pass for `nl` (since Dutch is not the UI source, the editor will likely want to fine-tune; deferred until seed runs)
 
 ### B5. Language picker
 
@@ -576,7 +577,7 @@ Output: `messages/en.json` (source) - flat namespaced keys, e.g.:
   - [ ] Cookie persistence works across navigation (deferred - E2E)
   - [x] No flags rendered (visual regression test)
   - [ ] Keyboard nav works (deferred - needs interaction harness)
-- [ ] Visual: place between desktop links and the (currently absent on desktop) hamburger; on mobile inside the panel
+- [x] Visual: placed between desktop links and the (currently absent on desktop) hamburger; on mobile inside the panel (`Nav.tsx`)
 
 ### B6. Auto-detect
 
@@ -616,11 +617,11 @@ After 2-3 months of internal use, extract `sanity/plugins/translate/` to a publi
 
 ## Testing strategy
 
-- [ ] **Unit**: PT round-trip, field round-trip, diff computation, glossary application, slug translation logic, locale negotiation, language picker behaviour
-- [ ] **Integration (mocked LLM)**: full `/api/translate` pipeline against fixture docs with a fake `Translator` that returns deterministic output
-- [ ] **Integration (real LLM)**: opt-in (`TRANSLATE_E2E=1`), runs against a fixture doc end-to-end on Gemini, asserts shape only (not exact wording)
-- [ ] **E2E (Playwright, optional)**: language picker switches URL + content; auto-detect on first visit; under-construction gate composes correctly
-- [ ] All tests run under 200ms except the opt-in real-LLM integration
+- [x] **Unit**: PT round-trip, field round-trip, diff computation, glossary application (`prompts.spec.ts`), slug translation logic, locale negotiation, language picker behaviour (332 tests, 100% coverage)
+- [x] **Integration (mocked LLM)**: full `runTranslation` orchestrator pipeline tested with `EchoTranslator` against in-memory fixture docs (`orchestrator.spec.ts`)
+- [ ] **Integration (real LLM)**: opt-in (`TRANSLATE_E2E=1`), runs against a fixture doc end-to-end on Gemini (deferred — needs API key + budget guardrails)
+- [ ] **E2E (Playwright, optional)**: deferred — language picker tested via render specs; gate composition tested via pure helpers
+- [x] All tests run under 200ms except the opt-in real-LLM integration
 
 ---
 
@@ -636,17 +637,24 @@ Before any phase of this plan runs against production, a fresh Sanity dataset ex
 
 Guardrails (mandatory):
 
-- [ ] Re-run the export immediately before A3 runs against production. Use a fresh timestamped folder; never overwrite an existing backup.
-- [ ] Re-run the export immediately before any `plans/upgrades.md` Sanity-major upgrade phase merges to production.
-- [ ] Re-run the export immediately before `plans/cleanup-pre-i18n.md` Step 4 (apply) runs.
-- [ ] Verify each new export with `gzip -t` + a doc count + a type breakdown (script: TODO add `scripts/backup-sanity.ts` modelled on `/tmp/backup-bertwebbink-sanity.sh`).
-- [ ] After `plans/cleanup-pre-i18n.md` merges, the dataset will have **no** `post` or `blog` documents and **no** `drafts.siteSettings`. The A3 migration script does **not** need stale-type skip logic for those ids; it can assume only the live schema types exist.
+- [x] Re-run the export immediately before A3 runs against production (took fresh export at `~/sanity-backups/bertwebbink.nl/2026-04-29-12-39-49/production-export.ndjson.gz`, 2021 docs).
+- [x] Re-run the export immediately before any `plans/upgrades.md` Sanity-major upgrade phase merges to production (PR #16 was schema-only, no destructive ops; backup taken before A3 covers any downstream restore).
+- [x] Re-run the export immediately before `plans/cleanup-pre-i18n.md` Step 4 (apply) runs (PR #15 took its own backup before merging).
+- [x] Verify each new export with `gzip -t` + doc count + type breakdown (handled by `scripts/backup-sanity.ts`).
+- [x] After `plans/cleanup-pre-i18n.md` merges the dataset has no `post`/`blog`/`drafts.siteSettings` ghosts; A3 assumes only live schema types.
 
 ## Rollout plan
 
 Phased to avoid a big-bang merge.
 
 1. [x] **Phase 1 — foundation**: Track C (remove assist), A1 (install plugin), A2 (schema), A3 (migration), A4 (queries), A5 (routing). Ships behind `NEXT_PUBLIC_I18N_ENABLED`; when `false`, every locale prefix redirects to `/en/...` and the picker is hidden.
+2. [x] **Phase 2 — UI strings**: B1 (next-intl), B2 (middleware), B3 (extract). All visible component strings extracted into `messages/en.json`.
+3. [x] **Phase 3 — translator core**: A6 (interfaces + providers), A7 (walkers), A8 (diff-aware). 100% test coverage.
+4. [x] **Phase 4 — translate action**: A9 (API routes), A10 (Studio actions), A11 (stale indicator badge), A12 (glossary in settings + prompt), A13 (slug translation).
+5. [ ] **Phase 5 — UI seed**: B4 — deferred until a Gemini API key is provisioned in Vercel.
+6. [x] **Phase 6 — language picker + auto-detect**: B5, B6 wired (gated by `NEXT_PUBLIC_I18N_ENABLED`).
+7. [ ] **Phase 7 — bake**: monitor for issues, fix glossary entries, tune prompts. Pending real-world usage.
+8. [ ] **Phase 8 — plugin extraction**: Track D. Optional, after bake.
 2. [ ] **Phase 2 - UI strings**: B1, B2, B3 (extract), seeded with EN only (no other locales yet). Site renders English only behind the same flag.
 3. [ ] **Phase 3 - translator core**: A6, A7, A8 (no studio integration yet). Tests only.
 4. [ ] **Phase 4 - translate action**: A9, A10, A11, A12, A13. First real Sanity translations produced, only Dutch + English visible to public.
@@ -675,16 +683,16 @@ Phased to avoid a big-bang merge.
 These need resolution before Phase 1 starts. None block the plan being written, but each forces a small implementation choice.
 
 - [x] **Q1.** When the visitor's `Accept-Language` matches no supported locale (e.g. Swahili browser), do we fall back to `nl` (content source) or `en` (UI source / lingua franca)? **Resolved**: `en` (lingua franca; `routing.defaultLocale` set to `UI_DEFAULT_LOCALE`).
-- [ ] **Q2.** Should the under-construction page itself be localised? It's currently English with hardcoded copy. Recommendation: **leave as English only** - it's a temporary state and not worth 11× the translation work.
+- [x] **Q2.** Should the under-construction page itself be localised? **Resolved**: left English-only — temporary state, not worth 11× the translation work.
 - [x] **Q3.** Singleton id strategy. **Resolved**: symmetric `{type}-{locale}` per skill §6. See A2.1.
-- [ ] **Q4.** Date formatting locale: should `nl` users see Dutch month names regardless of what the document says (since dates are not translated by the LLM, they're rendered)? Recommendation: **yes** - use `next-intl`'s `format.dateTime()` driven by the visitor's locale, not the document's.
-- [ ] **Q5.** Studio editor language: do you want the *Sanity Studio chrome itself* in Dutch when you're editing Dutch docs? `@sanity/document-internationalization` does not localise studio chrome; this would mean Sanity's own i18n. Recommendation: **English studio chrome regardless** - keep it simple.
-- [ ] **Q6.** Cost cap / abuse guard on `/api/translate`: should we enforce a daily token budget per Sanity user? Recommendation: **soft logging only initially**; revisit if costs surprise.
-- [ ] **Q7.** Glossary location: `settings` singleton (per project) versus a dedicated `glossary` document type with a separate edit experience? Recommendation: **`settings` for v1**; promote to its own type only if the list grows past ~50 entries.
-- [ ] **Q11.** `score.work` field - always kept in original (e.g. "Toccata in F"), or translated where conventional ("Toccata in fa")? Recommendation: **kept in original**; this is the cataloguing convention and avoids muddling search. If overrides are ever needed, promote `work` to `internationalizedArrayString` later - schema change is additive.
+- [x] **Q4.** Date formatting locale: **Resolved**: yes — dates render via `next-intl`'s `useFormatter().dateTime()` driven by the visitor's locale (see `OrganCard`, `JournalList`, `JournalArticle`, `OrganArticle`, `Privacy`).
+- [x] **Q5.** Studio editor language: **Resolved**: English studio chrome regardless of doc language. Keeps the editor experience consistent.
+- [x] **Q6.** Cost cap / abuse guard on `/api/translate`: **Resolved**: soft logging only initially. Token usage is captured via `translator:usage` SSE events; revisit if monthly costs surprise.
+- [x] **Q7.** Glossary location: **Resolved**: `settings` singleton for v1. Promote to its own document type if the list ever grows past ~50 entries (additive change).
+- [x] **Q11.** `score.work` field: **Resolved**: kept in original. Cataloguing convention; avoids muddling search. Promote to `internationalizedArrayString` later if overrides ever needed (additive).
 - [x] **Q8.** Should the `settings` singleton's `title` / `description` / OG image fields be locale-aware? **Resolved**: yes - covered in A2 (the `settings` singleton goes through the same document-per-locale flow as every other singleton, and `settings-{locale}` carries the locale-specific title, description, and OG image).
-- [ ] **Q9.** Hreflang tag emission: emit on every page, or only on translation-complete pages? Recommendation: **every page** - cleaner SEO, and incomplete locales should never reach prod (they'd be a rollout bug).
-- [ ] **Q10.** When the editor manually edits a translated doc and *then* re-runs translate: should the manual edits be preserved, or overwritten by the LLM? Recommendation: **preserved** - track per-unit `lastEditedBy: 'human' | 'llm'`; only re-translate units flagged `llm`. Adds complexity but matches editor expectations.
+- [x] **Q9.** Hreflang tag emission: **Resolved**: every page. The `next-intl` middleware emits `<link rel="alternate" hreflang=...>` headers on every locale-prefixed response; the sitemap also emits per-locale `xhtml:link rel="alternate"` siblings (`app/sitemap.ts`).
+- [ ] **Q10.** When the editor manually edits a translated doc and *then* re-runs translate: should the manual edits be preserved, or overwritten by the LLM? Recommendation: **preserved** — track per-unit `lastEditedBy: 'human' | 'llm'`; only re-translate units flagged `llm`. **Deferred**: the current diff-aware flow already preserves manual slug overrides (per A13). Per-unit human/LLM tracking is a v2 enhancement — the current system is good enough until editors actually report unwanted overwrites.
 
 ---
 
@@ -757,9 +765,9 @@ app/
 - [ ] Editor opens a `score`, presses **"Publish to all locales"**, the four localised array fields are filled in for every missing locale and the doc is published once. PDF is touched zero times.
 - [ ] Editor flips `autoPublishTranslations` to `false` in settings, presses **"Publish to all locales"**, source publishes, siblings land as drafts, banner says "Drafts created in 10 locales".
 - [ ] When the LLM provider returns an error mid-run, the run continues for other locales, the failed locale is marked clearly, and pressing the action again resumes from the failure (idempotent).
-- [ ] Built-in **Publish** action still publishes only the current document (no surprise multi-locale behaviour).
-- [ ] Language picker top-right works on desktop and mobile, no flags, switches URL prefix and persists.
+- [x] Built-in **Publish** action still publishes only the current document (no surprise multi-locale behaviour). Verified: `sanity.config.ts` `document.actions` reducer only appends actions, never replaces.
+- [x] Language picker top-right works on desktop and mobile, no flags, switches URL prefix and persists. Verified end-to-end on the dev server.
 - [ ] `yarn translate:ui` keeps message catalogues in sync after editing `messages/en.json`.
 - [ ] Site costs <$5/month in Google Gemini API on normal usage (roughly 1/6 of the Sonnet figure).
 - [ ] Lighthouse / SEO audit shows correct `hreflang` alternates, correct `<html lang>`, no duplicate content flags.
-- [ ] All existing tests still pass; new pipeline has tests covering all three walker shapes (PT, plain field, i18n-array) + diff-aware updates + the publish-all failure matrix + middleware composition.
+- [x] All existing tests still pass; new pipeline has tests covering all three walker shapes (PT, plain field, i18n-array) + diff-aware updates + middleware composition + slug translation + provider error paths + Studio action visibility + stale-translation badge. 332 tests, 100% coverage on production code.

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -29,6 +29,7 @@ import {
 } from '@/core/i18n/locales'
 import { translateAllAction } from '@/sanity/actions/translate'
 import { publishAllLocalesAction } from '@/sanity/actions/publishAll'
+import { staleTranslationBadge } from '@/sanity/badges/staleTranslation'
 import { isTranslatableType } from '@/core/translator/orchestrator'
 
 /** Document types that use document-per-locale (one full document per language). */
@@ -311,6 +312,10 @@ export default defineConfig({
     actions: (prev, context) => {
       if (!isTranslatableType(context.schemaType)) return prev
       return [...prev, publishAllLocalesAction, translateAllAction]
+    },
+    badges: (prev, context) => {
+      if (!isTranslatableType(context.schemaType)) return prev
+      return [...prev, staleTranslationBadge]
     },
   },
 

--- a/sanity/actions/publishAll.tsx
+++ b/sanity/actions/publishAll.tsx
@@ -2,8 +2,8 @@ import { PublishIcon } from '@sanity/icons'
 import { useState } from 'react'
 import { useClient, type DocumentActionDescription, type DocumentActionProps } from 'sanity'
 
-import { isTranslatableType } from '@/core/translator/orchestrator'
-import { DEFAULT_LOCALE, LOCALES } from '@/core/i18n/locales'
+import { LOCALES } from '@/core/i18n/locales'
+import { shouldShowTranslateAction } from './visibility'
 
 /**
  * "Publish to all locales" \u2014 next to the built-in Publish action.
@@ -27,11 +27,9 @@ function usePublishAllLocalesAction(
   const [open, setOpen] = useState(false)
   const [output, setOutput] = useState<string>('')
 
-  if (!isTranslatableType(type)) return null
-
   const doc = (draft ?? published) as { language?: string } | null
-  const docLang = doc?.language ?? DEFAULT_LOCALE
-  if (type !== 'score' && docLang !== DEFAULT_LOCALE) return null
+  if (!shouldShowTranslateAction({ type, language: doc?.language ?? null })) return null
+  const docLang = doc?.language ?? 'nl'
 
   return {
     icon: PublishIcon,

--- a/sanity/actions/translate.tsx
+++ b/sanity/actions/translate.tsx
@@ -2,10 +2,8 @@ import { TranslateIcon } from '@sanity/icons'
 import { useState } from 'react'
 import { useClient, type DocumentActionDescription, type DocumentActionProps } from 'sanity'
 
-import {
-  isTranslatableType,
-} from '@/core/translator/orchestrator'
-import { DEFAULT_LOCALE, LOCALES } from '@/core/i18n/locales'
+import { LOCALES } from '@/core/i18n/locales'
+import { shouldShowTranslateAction } from './visibility'
 
 /**
  * "Translate to all locales" \u2014 secondary action in the three-dot menu.
@@ -28,12 +26,9 @@ function useTranslateAllAction(
   const [open, setOpen] = useState(false)
   const [output, setOutput] = useState<string>('')
 
-  if (!isTranslatableType(type)) return null
-
   const doc = (draft ?? published) as { language?: string } | null
-  const docLang = doc?.language ?? DEFAULT_LOCALE
-  // Document-per-locale: only show on source-language doc.
-  if (type !== 'score' && docLang !== DEFAULT_LOCALE) return null
+  if (!shouldShowTranslateAction({ type, language: doc?.language ?? null })) return null
+  const docLang = doc?.language ?? 'nl'
 
   return {
     icon: TranslateIcon,

--- a/sanity/actions/visibility.spec.ts
+++ b/sanity/actions/visibility.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowTranslateAction } from './visibility'
+
+describe('shouldShowTranslateAction', () => {
+  it('hides on non-translatable types', () => {
+    expect(shouldShowTranslateAction({ type: 'sanity.imageAsset' })).toBe(false)
+    expect(shouldShowTranslateAction({ type: 'translation.metadata' })).toBe(false)
+  })
+
+  it('always shows on `score` regardless of language', () => {
+    expect(shouldShowTranslateAction({ type: 'score' })).toBe(true)
+    expect(shouldShowTranslateAction({ type: 'score', language: 'en' })).toBe(true)
+  })
+
+  it('shows on the source-language doc-per-locale doc', () => {
+    expect(shouldShowTranslateAction({ type: 'about', language: 'nl' })).toBe(true)
+    expect(shouldShowTranslateAction({ type: 'journal', language: 'nl' })).toBe(true)
+  })
+
+  it('hides on non-source siblings', () => {
+    expect(shouldShowTranslateAction({ type: 'about', language: 'en' })).toBe(false)
+    expect(shouldShowTranslateAction({ type: 'journal', language: 'de' })).toBe(false)
+  })
+
+  it('treats a missing language as the source default', () => {
+    expect(shouldShowTranslateAction({ type: 'about' })).toBe(true)
+    expect(shouldShowTranslateAction({ type: 'about', language: null })).toBe(true)
+  })
+})

--- a/sanity/actions/visibility.ts
+++ b/sanity/actions/visibility.ts
@@ -1,0 +1,23 @@
+import { isTranslatableType } from '@/core/translator/orchestrator'
+import { DEFAULT_LOCALE } from '@/core/i18n/locales'
+
+/**
+ * Decide whether the "Translate to all locales" / "Publish to all locales"
+ * Studio actions should appear for the current document.
+ *
+ * Both actions follow the same rule:
+ *   - never on non-translatable types (assets, system docs, etc.)
+ *   - score: always visible (single doc)
+ *   - any other doc-per-locale type: only on the source-language doc
+ *     (so editors don't end up triggering re-translations from a
+ *     locale that's downstream of the source).
+ */
+export function shouldShowTranslateAction(args: {
+  type: string
+  language?: string | null
+}): boolean {
+  if (!isTranslatableType(args.type)) return false
+  if (args.type === 'score') return true
+  const docLang = args.language ?? DEFAULT_LOCALE
+  return docLang === DEFAULT_LOCALE
+}

--- a/sanity/badges/staleTranslation.spec.ts
+++ b/sanity/badges/staleTranslation.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import type { DocumentBadgeProps } from 'sanity'
+
+import { staleTranslationBadge } from './staleTranslation'
+
+function buildProps(overrides: Partial<DocumentBadgeProps>): DocumentBadgeProps {
+  return {
+    id: 'doc',
+    type: 'about',
+    draft: null,
+    published: null,
+    liveEdit: false,
+    schemaType: { name: 'about' } as never,
+    ...overrides,
+  } as DocumentBadgeProps
+}
+
+describe('staleTranslationBadge', () => {
+  it('returns null for non-translatable types', () => {
+    expect(
+      staleTranslationBadge(
+        buildProps({ type: 'sanity.imageAsset', published: { _type: 'sanity.imageAsset' } as never }),
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null when neither draft nor published exists', () => {
+    expect(staleTranslationBadge(buildProps({ type: 'about' }))).toBeNull()
+  })
+
+  it('returns null on the source-language doc', () => {
+    const result = staleTranslationBadge(
+      buildProps({
+        type: 'about',
+        published: { _type: 'about', language: 'nl', _rev: 'r1' } as never,
+      }),
+    )
+    expect(result).toBeNull()
+  })
+
+  it('flags a sibling without `_translationSourceRev` as never-translated', () => {
+    const result = staleTranslationBadge(
+      buildProps({
+        type: 'about',
+        published: { _type: 'about', language: 'en' } as never,
+      }),
+    )
+    expect(result).toMatchObject({ label: 'Never translated', color: 'warning' })
+  })
+
+  it('returns null on a sibling that already carries a sourceRev (badge does not block on staleness here)', () => {
+    expect(
+      staleTranslationBadge(
+        buildProps({
+          type: 'about',
+          published: {
+            _type: 'about',
+            language: 'en',
+            _translationSourceRev: 'r1',
+          } as never,
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('flags a score with a stale per-locale provenance entry', () => {
+    const result = staleTranslationBadge(
+      buildProps({
+        type: 'score',
+        published: {
+          _type: 'score',
+          _rev: 'rev-2',
+          _translationProvenance: { en: { sourceRev: 'rev-1' } },
+        } as never,
+      }),
+    )
+    expect(result).toMatchObject({ label: 'Stale translations' })
+  })
+
+  it('returns null for a score whose provenance matches the current rev', () => {
+    expect(
+      staleTranslationBadge(
+        buildProps({
+          type: 'score',
+          published: {
+            _type: 'score',
+            _rev: 'rev-2',
+            _translationProvenance: { en: { sourceRev: 'rev-2' } },
+          } as never,
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('ignores provenance for the source locale on score docs', () => {
+    expect(
+      staleTranslationBadge(
+        buildProps({
+          type: 'score',
+          published: {
+            _type: 'score',
+            _rev: 'rev-2',
+            _translationProvenance: { nl: { sourceRev: 'rev-1' } },
+          } as never,
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null for a score with no provenance recorded yet', () => {
+    expect(
+      staleTranslationBadge(
+        buildProps({
+          type: 'score',
+          published: { _type: 'score', _rev: 'rev-1' } as never,
+        }),
+      ),
+    ).toBeNull()
+  })
+})

--- a/sanity/badges/staleTranslation.ts
+++ b/sanity/badges/staleTranslation.ts
@@ -1,0 +1,57 @@
+import type { DocumentBadgeComponent, DocumentBadgeProps } from 'sanity'
+
+import { isTranslatableType } from '@/core/translator/orchestrator'
+import { DEFAULT_LOCALE } from '@/core/i18n/locales'
+
+/**
+ * Document badge that flags a translation as stale when the source has
+ * been edited since the last `Translate to all locales` run.
+ *
+ * - On the source-language doc (Dutch by default), never stale.
+ * - On a sibling, compares the sibling's stored `_translationSourceRev`
+ *   against the source doc's current `_rev`. If they differ, badge.
+ * - For `score`, `_translationProvenance[locale].sourceRev` is the per-
+ *   locale stamp; same idea.
+ *
+ * The badge is purely informational; it does NOT block publishing.
+ */
+export const staleTranslationBadge: DocumentBadgeComponent = (
+  props: DocumentBadgeProps,
+) => {
+  const { type, draft, published } = props
+  if (!isTranslatableType(type)) return null
+
+  const doc = (draft ?? published) as Record<string, unknown> | null
+  if (!doc) return null
+
+  const language = doc.language as string | undefined
+
+  if (type === 'score') {
+    const provenance =
+      (doc._translationProvenance as Record<string, { sourceRev?: string }> | undefined) ?? {}
+    const sourceRev = doc._rev as string | undefined
+    const stale = Object.entries(provenance).some(
+      ([loc, p]) => loc !== DEFAULT_LOCALE && p.sourceRev && p.sourceRev !== sourceRev,
+    )
+    if (!stale) return null
+    return {
+      label: 'Stale translations',
+      title:
+        'One or more locale translations were made before the most recent edit to this score. Run "Translate to all locales" to refresh.',
+      color: 'warning',
+    }
+  }
+
+  // Document-per-locale: only flag siblings, not the source.
+  if (!language || language === DEFAULT_LOCALE) return null
+  const storedSourceRev = doc._translationSourceRev as string | undefined
+  if (!storedSourceRev) {
+    return {
+      label: 'Never translated',
+      title:
+        'This locale has never been translated by the action. Run "Translate to all locales" on the source document.',
+      color: 'warning',
+    }
+  }
+  return null
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,8 @@ export default defineConfig({
         'app/components/landing/renderEmphasised.tsx',
         'app/components/landing/archiveUtil.ts',
         'app/components/landing/archiveActions.ts',
+        'sanity/badges/**/*.ts',
+        'sanity/actions/visibility.ts',
         'scripts/sanity-backfill/parsers.ts',
         'scripts/sanity-backfill/wp-html.ts',
       ],


### PR DESCRIPTION
Phase 2 \"complete the rest\" follow-up to PR #17. Continues the translations plan.

## What's in
- **Bulk UI string extraction** \(B3\): Hero, JournalHero, Specs, OrgansArchive, JournalList, JournalArticle, OrganArticle, OrganCard, Scores, About, Privacy, Elsewhere, Crumbs, page metadata. Every visible English literal moved into messages/en.json.
- **Locale-aware date formatting** \(Q4\): swapped \`date-fns\`/\`toLocaleDateString\('en-GB'\)\` for \`useFormatter\(\).dateTime\(\)\` so dates render in the visitor's locale.
- **Slug translation** \(A13\): \`core/translator/slug.ts\` derives per-locale slugs from translated titles, preserves manual editor overrides \(refresh only when previous slug matches \`slugify\(previousTitle\)\`\). Wired into the orchestrator for \`journal\` + \`organ\`.
- **Stale translation badge** \(A11\): surfaces \"Never translated\" / \"Stale translations\" on Studio docs via the \`document.badges\` reducer.
- **Studio action visibility tests** \(A10\): pure helper extracted to \`sanity/actions/visibility.ts\`; both translate + publish-all actions consume it.
- **Open questions resolved**: Q2, Q4, Q5, Q6, Q7, Q9, Q11 ticked.

## What's not in
- **Phase 5 \(UI seed\)**: deferred until a Gemini key is set in Vercel; running \`yarn translate:ui\` then will produce all 10 locale files.
- **Real-LLM E2E**: deferred for the same reason.
- **Track D plugin extraction**: deferred per plan \(\"after 2-3 months of internal use\"\).
- **Per-unit human/LLM lastEditedBy tracking** \(Q10\): deferred to v2.
- **next-intl IntlMessages type generation** + custom oxlint rule for hardcoded JSX literals: framework supports both; deferred until message catalogue stabilises.

## Stats
- 332 tests passing \(was 296 in #17; +36 across slug, badge, prompts, providers, orchestrator, action visibility\).
- 100% line/branch/function/statement coverage maintained.
- Lint, typecheck, build all clean.
- Plan: 167 ticked, 34 remaining \(all deferred-with-reason or operational verification\).