### PR TITLE
fix(translations): pass locale to load-more action + stop LLM inventing <mN> markers

### DIFF
--- a/app/components/landing/OrgansArchive.tsx
+++ b/app/components/landing/OrgansArchive.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
+import type { Locale } from '@/core/i18n/locales'
 import { Link } from '@/i18n/navigation'
 
 import { OrganCard, type LandingOrgan } from './OrganCard'
@@ -20,6 +21,7 @@ type OrgansArchiveProps = {
 
 export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: OrgansArchiveProps) {
   const t = useTranslations('OrgansArchive')
+  const locale = useLocale() as Locale
   const [organs, setOrgans] = useState<LandingOrgan[]>(initialOrgans)
   const [loading, setLoading] = useState(false)
   const [exhausted, setExhausted] = useState(initialOrgans.length >= totalCount)
@@ -39,6 +41,7 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
         offset: organs.length,
         limit: PAGE_SIZE,
         city,
+        locale,
       })
       if (more.length === 0) {
         setExhausted(true)
@@ -52,7 +55,7 @@ export function OrgansArchive({ initialOrgans, totalCount, cityCounts, city }: O
     } finally {
       setLoading(false)
     }
-  }, [loading, exhausted, organs.length, city, totalCount])
+  }, [loading, exhausted, organs.length, city, locale, totalCount])
 
   useEffect(() => {
     const node = sentinelRef.current

--- a/app/components/landing/archiveActions.spec.ts
+++ b/app/components/landing/archiveActions.spec.ts
@@ -17,32 +17,44 @@ describe('loadMoreOrgans', () => {
     sanityFetchMock.mockReset()
   })
 
-  it('passes offset, end (offset+limit) and city to sanityFetch', async () => {
+  it('passes offset, end (offset+limit), city, and locale to sanityFetch', async () => {
     sanityFetchMock.mockResolvedValueOnce({ data: [] })
-    await loadMoreOrgans({ offset: 24, limit: 10, city: 'Urk' })
+    await loadMoreOrgans({ offset: 24, limit: 10, city: 'Urk', locale: 'nl' })
     expect(sanityFetchMock).toHaveBeenCalledTimes(1)
     expect(sanityFetchMock).toHaveBeenCalledWith({
       query: '<<archiveOrgansQuery>>',
-      params: { offset: 24, end: 34, city: 'Urk' },
+      params: { offset: 24, end: 34, city: 'Urk', locale: 'nl' },
     })
   })
 
   it('returns the data array verbatim when present', async () => {
     const rows = [{ _id: 'a' }, { _id: 'b' }]
     sanityFetchMock.mockResolvedValueOnce({ data: rows })
-    const result = await loadMoreOrgans({ offset: 0, limit: 24, city: '' })
+    const result = await loadMoreOrgans({ offset: 0, limit: 24, city: '', locale: 'en' })
     expect(result).toBe(rows)
   })
 
   it('returns an empty array when sanityFetch yields no data', async () => {
     sanityFetchMock.mockResolvedValueOnce({ data: null })
-    const result = await loadMoreOrgans({ offset: 0, limit: 24, city: '' })
+    const result = await loadMoreOrgans({ offset: 0, limit: 24, city: '', locale: 'en' })
     expect(result).toEqual([])
   })
 
   it('returns an empty array when data is undefined', async () => {
     sanityFetchMock.mockResolvedValueOnce({})
-    const result = await loadMoreOrgans({ offset: 0, limit: 24, city: '' })
+    const result = await loadMoreOrgans({ offset: 0, limit: 24, city: '', locale: 'en' })
     expect(result).toEqual([])
+  })
+
+  it('rejects bogus locale strings without hitting Sanity', async () => {
+    const result = await loadMoreOrgans({
+      offset: 0,
+      limit: 24,
+      city: '',
+      // Cast bypasses the typed signature so we exercise the runtime guard.
+      locale: 'sw' as never,
+    })
+    expect(result).toEqual([])
+    expect(sanityFetchMock).not.toHaveBeenCalled()
   })
 })

--- a/app/components/landing/archiveActions.ts
+++ b/app/components/landing/archiveActions.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { LOCALES, type Locale } from '@/core/i18n/locales'
 import { sanityFetch } from '@/sanity/lib/live'
 import { archiveOrgansQuery } from '@/sanity/lib/queries'
 import type { LandingOrgan } from './OrganCard'
@@ -10,19 +11,25 @@ import type { LandingOrgan } from './OrganCard'
  * `limit` organs starting at `offset`, optionally filtered by `city`.
  *
  * `city` is an empty string for "no filter" — matches the GROQ sentinel.
+ * `locale` is required by the locale-aware GROQ query (`language == $locale`)
+ * and is validated against the known locale list to keep this server
+ * action resilient to bogus client input.
  */
 export async function loadMoreOrgans({
   offset,
   limit,
   city,
+  locale,
 }: {
   offset: number
   limit: number
   city: string
+  locale: Locale
 }): Promise<LandingOrgan[]> {
+  if (!(LOCALES as readonly string[]).includes(locale)) return []
   const { data } = await sanityFetch({
     query: archiveOrgansQuery,
-    params: { offset, end: offset + limit, city },
+    params: { offset, end: offset + limit, city, locale },
   })
   return (data ?? []) as LandingOrgan[]
 }

--- a/core/translator/prompts.spec.ts
+++ b/core/translator/prompts.spec.ts
@@ -89,6 +89,14 @@ describe('buildSystemPrompt', () => {
     expect(noContextPrompt).not.toMatch(/Organ-domain note/)
   })
 
+  it('explains both <mN> and {{...}} marker syntaxes and forbids introducing them', () => {
+    const prompt = buildSystemPrompt(baseReq)
+    expect(prompt).toMatch(/<m1>\.\.\.<\/m1>/)
+    expect(prompt).toMatch(/\{\{\.\.\.\}\}/)
+    expect(prompt).toMatch(/MUST NOT invent/)
+    expect(prompt).toMatch(/Do NOT convert \{\{\.\.\.\}\} to <m1>/)
+  })
+
   it('asks the LLM to reuse previous translations when provided', () => {
     const prompt = buildSystemPrompt({
       ...baseReq,

--- a/core/translator/prompts.ts
+++ b/core/translator/prompts.ts
@@ -18,7 +18,13 @@ export function buildSystemPrompt(req: TranslateRequest): string {
     `You are a professional translator translating ${sourceName} (${req.sourceLocale}) text into ${targetName} (${req.targetLocale}).`,
   )
   lines.push(
-    'You MUST preserve every inline formatting marker exactly as given. Inline markers in the source look like <m1>...</m1>, <m2>...</m2> and so on; the integers and tag names must be present in the translation, wrapping the equivalent translated phrase.',
+    'You MUST preserve every inline formatting marker exactly as given, AND you MUST NOT invent new ones. There are two kinds:',
+  )
+  lines.push(
+    '  1. Numbered tags: <m1>...</m1>, <m2>...</m2>, ... (used in long-form prose). When present in the source, keep the exact same tag names and integers, wrapping the equivalent translated phrase. When NOT present in the source, do NOT introduce them.',
+  )
+  lines.push(
+    '  2. Brace-italic markers: {{...}} (used in short labels and titles to italicise the wrapped phrase on render). Preserve them verbatim when present in the source. Do NOT convert {{...}} to <m1>...</m1> or vice-versa, and do NOT add brace markers around words that the source did not already wrap.',
   )
   if (shape === 'portable-text') {
     lines.push(

--- a/scripts/fix-marker-leaks.ts
+++ b/scripts/fix-marker-leaks.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env tsx
+/**
+ * One-shot: rewrite leaked `<mN>...</mN>` markers back to the
+ * site's brace-italic syntax `{{...}}` in stored translation docs.
+ *
+ * Background: a previous translator-prompt iteration told the LLM
+ * that "inline formatting markers look like <m1>...</m1>". When the
+ * source string used the brace-italic convention (`{{Bach}}`), the
+ * LLM helpfully converted it to `<m1>Bach</m1>` thinking that was
+ * the canonical syntax. The brace form is what the renderer parses
+ * (see `renderEmphasised.tsx`); the numbered-tag form leaks through
+ * to the rendered text because there's nothing post-translate that
+ * decodes them in plain string fields.
+ *
+ * Scope: every translatable doc-per-locale type, every translatable
+ * string field. Intentionally NOT walking Portable Text (`letter`,
+ * `content`) because those fields legitimately use `<mN>` markers
+ * during the translation round-trip and are decoded back to marks
+ * by the PT walker.
+ *
+ * Usage:
+ *   yarn tsx scripts/fix-marker-leaks.ts            # apply
+ *   yarn tsx scripts/fix-marker-leaks.ts --dry-run  # preview
+ */
+
+import 'dotenv/config'
+
+import { createClient } from '@sanity/client'
+
+const projectId = required('NEXT_PUBLIC_SANITY_PROJECT_ID')
+const dataset = required('NEXT_PUBLIC_SANITY_DATASET')
+const apiVersion = process.env.NEXT_PUBLIC_SANITY_API_VERSION || '2024-10-28'
+const writeToken = required('SANITY_API_WRITE_TOKEN')
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    console.error(`Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}
+
+/**
+ * Replace every `<m\d+>...</m\d+>` pair with `{{...}}`. Tolerates
+ * mismatched numbers and nested markers (the regex is non-greedy and
+ * walks left to right). Returns the string verbatim if no markers
+ * are present so the caller can detect a no-op.
+ */
+function convertMarkers(value: string): string {
+  return value.replace(/<m\d+>([\s\S]*?)<\/m\d+>/g, '{{$1}}')
+}
+
+/**
+ * Recursively walk a doc, replacing every string leaf via `convertMarkers`.
+ * Returns a new value when any string changed, else the input verbatim.
+ * Skips Portable Text-shaped fields (`content`, `letter`) because those
+ * contain block-level structures whose `<mN>` markers are managed by
+ * the PT walker, not leaked into rendered text.
+ */
+const PT_FIELDS = new Set(['content', 'letter'])
+
+function walk(value: unknown): { value: unknown; changed: boolean } {
+  if (value == null) return { value, changed: false }
+  if (typeof value === 'string') {
+    if (!value.includes('<m')) return { value, changed: false }
+    const next = convertMarkers(value)
+    return next === value ? { value, changed: false } : { value: next, changed: true }
+  }
+  if (Array.isArray(value)) {
+    let changed = false
+    const out: unknown[] = []
+    for (const item of value) {
+      const { value: nextItem, changed: itemChanged } = walk(item)
+      out.push(nextItem)
+      if (itemChanged) changed = true
+    }
+    return changed ? { value: out, changed: true } : { value, changed: false }
+  }
+  if (typeof value === 'object') {
+    let changed = false
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (PT_FIELDS.has(k)) {
+        out[k] = v
+        continue
+      }
+      const { value: nextV, changed: vChanged } = walk(v)
+      out[k] = nextV
+      if (vChanged) changed = true
+    }
+    return changed ? { value: out, changed: true } : { value, changed: false }
+  }
+  return { value, changed: false }
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run')
+  const client = createClient({
+    projectId,
+    dataset,
+    apiVersion,
+    token: writeToken,
+    useCdn: false,
+    perspective: 'raw',
+  })
+
+  type Doc = Record<string, unknown> & { _id: string; _type: string; language?: string }
+  const docs = await client.fetch<Doc[]>(
+    `*[_type in ["organ","journal","about","elsewhere","privacy","scoresPage","organsPage","journalPage","settings","score"] && language != "nl" && !(_id in path("drafts.**"))]`,
+  )
+  console.log(`Loaded ${docs.length} non-source translation doc(s)`)
+
+  let patched = 0
+  for (const doc of docs) {
+    const { value: nextDoc, changed } = walk(doc) as { value: Doc; changed: boolean }
+    if (!changed) continue
+    patched++
+    console.log(`  ${doc._id} (${doc._type}, ${doc.language})`)
+    if (!dryRun) {
+      // Strip system fields before re-writing so createOrReplace
+      // doesn't fight Sanity's own bookkeeping.
+      const stripped: Record<string, unknown> = {}
+      for (const [k, v] of Object.entries(nextDoc)) {
+        if (k === '_rev' || k === '_createdAt' || k === '_updatedAt') continue
+        stripped[k] = v
+      }
+      await client.createOrReplace(stripped as never)
+    }
+  }
+  console.log(`\n${dryRun ? '[DRY-RUN] ' : ''}rewrote markers in ${patched} doc(s)`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Two bugs surfaced after the fresh translation pass:

## 1. GROQ \`\$locale\` parse error on organ archive scroll

The server action that powers infinite scroll forwarded \`{ offset, limit, city }\` to a GROQ query that also needs \`\$locale\` (\`language == \$locale\`). Every scroll past the first page surfaced \`param \$locale referenced, but not provided\` server-side.

- Plumbed \`locale\` through from the client via \`useLocale()\`
- Server action validates against the \`LOCALES\` allow-list before hitting Sanity

## 2. Literal \`<m1>...</m1>\` tags rendered on About page

The system prompt told the LLM "inline formatting markers look like \`<m1>...</m1>\`". For PT shape that's true (the walker round-trips them), but on short string fields the source uses \`{{...}}\` brace-italics. The LLM converted \`{{Bach}}\` -> \`<m1>Bach</m1>\`, and the renderer (which only parses \`{{...}}\`) showed the raw tags.

- Prompt now describes both marker syntaxes and explicitly forbids converting between them
- New \`scripts/fix-marker-leaks.ts\` walks every non-source doc, rewrites \`<mN>...</mN>\` -> \`{{...}}\` on string leaves only (PT fields skipped \u2014 the PT walker handles those legitimately). Ran in prod: 25 docs patched.

**Tests:** 365 passing (was 363), 100% coverage. **Lint:** clean. **Typecheck:** clean.